### PR TITLE
vk_video_decoder: check width/height vs minimums + alignments

### DIFF
--- a/vk_video_decoder/libs/NvVkDecoder/NvVkDecoder.cpp
+++ b/vk_video_decoder/libs/NvVkDecoder/NvVkDecoder.cpp
@@ -658,6 +658,16 @@ int32_t NvVkDecoder::StartVideoSequence(VkParserDetectedVideoFormat* pVideoForma
         vk::GetPhysicalDeviceVideoCapabilitiesKHR(m_pVulkanDecodeContext.physicalDev,
             videoProfile.GetProfile(),
             &videoDecodeCapabilities);
+
+	if (m_width < videoDecodeCapabilities.minExtent.width)
+            m_width = videoDecodeCapabilities.minExtent.width;
+	if (m_height < videoDecodeCapabilities.minExtent.height)
+            m_height = videoDecodeCapabilities.minExtent.height;
+
+        unsigned w_align = videoDecodeCapabilities.videoPictureExtentGranularity.width - 1;
+        m_width = ((m_width + w_align) & ~w_align);
+        unsigned h_align = videoDecodeCapabilities.videoPictureExtentGranularity.height - 1;
+        m_height = ((m_height + h_align) & ~h_align);
     }
 
     static const VkExtensionProperties h264StdExtensionVersion = { VK_STD_VULKAN_VIDEO_CODEC_H264_EXTENSION_NAME, VK_STD_VULKAN_VIDEO_CODEC_H264_SPEC_VERSION };


### PR DESCRIPTION

This is just a couple of simple bits to fix the image alignment on my impl of vulkan video.

I think there should be more checks against max extent and the bitstream alignments, but this gets me past my current hurdle.