### PR TITLE
VulkanVideoParser: Fix maxActiveReferencePictures validation error

### DIFF
--- a/vk_video_decoder/libs/VkVideoParser/VulkanVideoParser.cpp
+++ b/vk_video_decoder/libs/VkVideoParser/VulkanVideoParser.cpp
@@ -44,7 +44,7 @@ static const uint32_t bottomFieldMask = (1 << bottomFieldShift);
 static const uint32_t fieldIsReferenceMask = (topFieldMask | bottomFieldMask);
 
 static const uint32_t MAX_DPB_REF_SLOTS = 16;
-static const uint32_t MAX_DPB_REF_AND_SETUP_SLOTS = MAX_DPB_REF_SLOTS + 1; // plus 1 for the current picture (h.264 only)
+static const uint32_t MAX_DPB_REF_AND_SETUP_SLOTS = MAX_DPB_REF_SLOTS; // plus 1 for the current picture (h.264 only)
 
 #define COPYFIELD(pout, pin, name) pout->name = pin->name
 


### PR DESCRIPTION
According to
https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkVideoSessionCreateInfoKHR-maxActiveReferencePictures-04849

the maxActiveReferencePictures should not exceed 16