### PR TITLE
FFMpegDemuxer: add missing subsampling AV_PIX_FMT_YUVJ420P

### DIFF
--- a/vk_video_decoder/libs/NvCodecUtils/FFmpegDemuxer.cpp
+++ b/vk_video_decoder/libs/NvCodecUtils/FFmpegDemuxer.cpp
@@ -357,6 +357,7 @@ public:
     virtual VkVideoChromaSubsamplingFlagsKHR GetChromaSubsampling() const
     {
         switch (format) {
+        case AV_PIX_FMT_YUVJ420P:
         case AV_PIX_FMT_YUV420P:     ///< planar YUV 4:2:0, 12bpp, (1 Cr & Cb sample per 2x2 Y samples)
         case AV_PIX_FMT_YUV420P10LE: ///< planar YUV 4:2:0, 15bpp, (1 Cr & Cb sample per 2x2 Y samples), little-endian
         case AV_PIX_FMT_YUV420P16LE: ///< planar YUV 4:2:0, 24bpp, (1 Cr & Cb sample per 2x2 Y samples), little-endian


### PR DESCRIPTION
With given hevc sample generated with GStreamer:

gst-launch-1.0 videotestsrc num_buffers=300 pattern=ball ! timeoverlay ! nvh265enc  ! filesink location=/tmp/Sample_300.hevc