### PR TITLE
Fixes for running on mesa

### DIFF
--- a/vk_video_decoder/libs/VkCodecUtils/Helpers.h
+++ b/vk_video_decoder/libs/VkCodecUtils/Helpers.h
@@ -26,7 +26,7 @@
 namespace vk {
 
 inline VkResult assert_success(VkResult res) {
-    if (res != VK_SUCCESS) {
+    if (res != VK_SUCCESS && res != VK_SUBOPTIMAL_KHR) {
         std::stringstream ss;
         ss << "VkResult " << res << " returned";
         throw std::runtime_error(ss.str());

--- a/vk_video_decoder/libs/VkCodecUtils/VulkanVideoUtils.cpp
+++ b/vk_video_decoder/libs/VkCodecUtils/VulkanVideoUtils.cpp
@@ -503,9 +503,6 @@ VkResult ImageObject::FillImageWithPattern(int pattern)
 
     m_vkDevCtx->GetImageSubresourceLayout(*m_vkDevCtx, image, &subres, &layout);
 
-    CALL_VK(m_vkDevCtx->MapMemory(*m_vkDevCtx, mem, 0, allocationSize, 0, &data));
-
-
     const VkMpFormatInfo* mpInfo = YcbcrVkFormatInfo(imageFormat);
     if (mpInfo) {
         ImageData imageData =
@@ -520,12 +517,13 @@ VkResult ImageObject::FillImageWithPattern(int pattern)
         VkFillYuv vkFillYuv;
         vkFillYuv.fillVkImage(m_vkDevCtx, image, &imageData, mem, &ycbcrConversionInfo);
     } else {
+        CALL_VK(m_vkDevCtx->MapMemory(*m_vkDevCtx, mem, 0, allocationSize, 0, &data));
         generateColorPatternRgba8888((ColorPattern)pattern, (uint8_t *)data,
                                  imageWidth, imageHeight,
                                  (uint32_t)layout.rowPitch);
+        m_vkDevCtx->UnmapMemory(*m_vkDevCtx, mem);
     }
 
-    m_vkDevCtx->UnmapMemory(*m_vkDevCtx, mem);
 
     return VK_SUCCESS;
 }

--- a/vk_video_decoder/libs/VkShell/Shell.cpp
+++ b/vk_video_decoder/libs/VkShell/Shell.cpp
@@ -304,9 +304,9 @@ void Shell::AcquireBackBuffer(bool trainFrame) {
     // acquire just once when not presenting
     if (m_settings.noPresent && GetCurrentBackBuffer().GetAcquireSemaphore() != VK_NULL_HANDLE) return;
 
-    AcquireBuffer* acquireBuf = m_ctx.acquireBuffers.front();
+    assert(!m_ctx.acquireBuffers.empty());
 
-    assert(acquireBuf != nullptr);
+    AcquireBuffer* acquireBuf = m_ctx.acquireBuffers.front();
 
     uint32_t imageIndex = 0;
     vk::assert_success(


### PR DESCRIPTION
Fixes from #41 for correctness issues.

You can also see the other changes required to run on mesa in https://github.com/kkartaltepe/vk_video_samples/tree/minimal-runnable that cover the other issues mentioned. But note minimal branch does not render correctly, as the dpb workaround is not correct.