### PR TITLE
chore: suppress warning about `static_assert`

### DIFF
--- a/common/include/VkVideoCore/VkVideoCoreProfile.h
+++ b/common/include/VkVideoCore/VkVideoCoreProfile.h
@@ -35,10 +35,10 @@ typedef enum StdChromaFormatIdc {
 } StdChromaFormatIdc;
 
 #if defined(__linux) || defined(__linux__) || defined(linux)
-static_assert((uint32_t)chroma_format_idc_monochrome == (uint32_t)STD_VIDEO_H265_CHROMA_FORMAT_IDC_MONOCHROME);
-static_assert((uint32_t)chroma_format_idc_420        == (uint32_t)STD_VIDEO_H265_CHROMA_FORMAT_IDC_420);
-static_assert((uint32_t)chroma_format_idc_422        == (uint32_t)STD_VIDEO_H265_CHROMA_FORMAT_IDC_422);
-static_assert((uint32_t)chroma_format_idc_444        == (uint32_t)STD_VIDEO_H265_CHROMA_FORMAT_IDC_444);
+static_assert((uint32_t)chroma_format_idc_monochrome == (uint32_t)STD_VIDEO_H265_CHROMA_FORMAT_IDC_MONOCHROME, "");
+static_assert((uint32_t)chroma_format_idc_420        == (uint32_t)STD_VIDEO_H265_CHROMA_FORMAT_IDC_420, "");
+static_assert((uint32_t)chroma_format_idc_422        == (uint32_t)STD_VIDEO_H265_CHROMA_FORMAT_IDC_422, "");
+static_assert((uint32_t)chroma_format_idc_444        == (uint32_t)STD_VIDEO_H265_CHROMA_FORMAT_IDC_444, "");
 #endif
 
 class VkVideoCoreProfile


### PR DESCRIPTION
Using `static_assert` without an error string is a C++17 extension (https://en.cppreference.com/w/cpp/language/static_assert)

Adding an empty string suppresses noisy warnings since this header gets included in many places. Alternatively, the assertions could be removed

```
[20/21] Building CXX object demos/vk-video-dec/CMakeFiles/vk-video-dec-test.dir/__/__/libs/VkVideoDecoder/VkVideoDecoder.cpp.o
In file included from /home/stephan/projects/vk_video_samples/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp:21:
In file included from /home/stephan/projects/vk_video_samples/vk_video_decoder/../common/include/VkVideoCore/VulkanVideoCapabilities.h:24:
/home/stephan/projects/vk_video_samples/common/include/VkVideoCore/VkVideoCoreProfile.h:38:110: warning: 'static_assert' with no message is a C++17 extension [-Wc++17-extensions
]
static_assert((uint32_t)chroma_format_idc_monochrome == (uint32_t)STD_VIDEO_H265_CHROMA_FORMAT_IDC_MONOCHROME);
                                                                                                             ^
                                                                                                             , ""
/home/stephan/projects/vk_video_samples/common/include/VkVideoCore/VkVideoCoreProfile.h:39:103: warning: 'static_assert' with no message is a C++17 extension [-Wc++17-extensions
]
static_assert((uint32_t)chroma_format_idc_420        == (uint32_t)STD_VIDEO_H265_CHROMA_FORMAT_IDC_420);
                                                                                                      ^
                                                                                                      , ""
/home/stephan/projects/vk_video_samples/common/include/VkVideoCore/VkVideoCoreProfile.h:40:103: warning: 'static_assert' with no message is a C++17 extension [-Wc++17-extensions
]
static_assert((uint32_t)chroma_format_idc_422        == (uint32_t)STD_VIDEO_H265_CHROMA_FORMAT_IDC_422);
                                                                                                      ^
                                                                                                      , ""
/home/stephan/projects/vk_video_samples/common/include/VkVideoCore/VkVideoCoreProfile.h:41:103: warning: 'static_assert' with no message is a C++17 extension [-Wc++17-extensions
]
static_assert((uint32_t)chroma_format_idc_444        == (uint32_t)STD_VIDEO_H265_CHROMA_FORMAT_IDC_444);
                                                                                                      ^
                                                                                                      , ""
```