### PR TITLE
Fix double vkUnmap calls

### DIFF
--- a/common/libs/VkCodecUtils/pattern.cpp
+++ b/common/libs/VkCodecUtils/pattern.cpp
@@ -696,8 +696,6 @@ void VkFillYuv::fillVkImage(const VulkanDeviceContext* vkDevCtx,
 
     result = vkDevCtx->FlushMappedMemoryRanges(*vkDevCtx, 1u, &range);
     ABORT_IF_TRUE(result != VK_SUCCESS);
-
-    vkDevCtx->UnmapMemory(*vkDevCtx, mem);
 }
 
 } // namespace Pattern


### PR DESCRIPTION
Appears to be missed in f289815. The memory should be mapped and unmapped by VulkanDeviceMemoryImpl.

Related to #41.