### PR TITLE
Fix bit checking in MapMemoryTypeToIndex

### DIFF
--- a/common/libs/VkCodecUtils/Helpers.h
+++ b/common/libs/VkCodecUtils/Helpers.h
@@ -208,8 +208,8 @@ inline VkResult MapMemoryTypeToIndex(const VkInterfaceFunctions* vkIf,
     VkPhysicalDeviceMemoryProperties memoryProperties;
     vkIf->GetPhysicalDeviceMemoryProperties(vkPhysicalDev, &memoryProperties);
     // Search memtypes to find first index with those properties
-    for (uint32_t i = 0; i < 32; i++) {
-        if ((typeBits & 1) == 1) {
+    for (uint32_t i = 0; i < memoryProperties.memoryTypeCount; i++) {
+        if ((typeBits & (1 << i)) == 1) {
             // Type is available, does it match user properties?
             if ((memoryProperties.memoryTypes[i].propertyFlags & requirements_mask) ==
                     requirements_mask) {


### PR DESCRIPTION
Respect `memoryTypeCount` and check the correct `typeBits` bit.