### PR TITLE
Implement `--help` for decoder app CLI and additional CLI arg validation

### DIFF
--- a/common/libs/VkCodecUtils/ProgramConfig.h
+++ b/common/libs/VkCodecUtils/ProgramConfig.h
@@ -255,6 +255,31 @@ struct ProgramConfig {
                 exit(EXIT_FAILURE);
             }
 
+            bool disableValueCheck = false;
+            if (i + 1 < argc && strcmp(argv[i + 1], "--") == 0) {
+                if (i + 1 + flag->numArgs >= argc) {
+                    std::cerr << "Missing arguments for \"" << argv[i] << "\"" << std::endl;
+                    exit(EXIT_FAILURE);
+                }
+                disableValueCheck = true; 
+                i++;
+            }
+
+            // Only allow values not starting with `-` unless prefixed with `-- ` (e.g. -i -- --inputfile-starting-with-minus)
+            // This allows us to give better error messages as we don't expect any values to start with `-`
+            if (!disableValueCheck) {
+                for (int j = 1; j <= flag->numArgs; j++) {
+                    if (argv[i + j][0] == '-') {
+                        std::cerr << "Invalid value \"" << argv[i + j] << "\" for \"" << argv[i] << "\" "
+                            "(we don't allow values starting with `-` by default). You probably missed to "
+                            "set a value for \"" << argv[i] << "\"." << std::endl;
+                        std::cerr << "Use \"-- " << argv[i + j] << "\" if you meant to set \"" << argv[i + j]
+                            << "\" for \"" << argv[i] << "\"." << std::endl;
+                        exit(EXIT_FAILURE);
+                    }
+                }
+            }
+
             if (!flag->lambda(argv + i + 1, spec)) {
                 exit(EXIT_FAILURE);
             }

--- a/common/libs/VkCodecUtils/ProgramConfig.h
+++ b/common/libs/VkCodecUtils/ProgramConfig.h
@@ -58,7 +58,6 @@ struct ProgramConfig {
         validate = false;
         validateVerbose = false;
 
-        noTick = false;
         noPresent = false;
 
         maxFrameCount = -1;
@@ -101,7 +100,7 @@ struct ProgramConfig {
 
     void ParseArgs(int argc, const char *argv[]) {
         ProgramArgs spec = {
-            {"--help", "-h", 0, "Show this help",
+            {"--help", nullptr, 0, "Show this help",
                 [argv](const char **, const ProgramArgs &a) {
                     int rtn = showHelp(argv, a);
                     exit(EXIT_SUCCESS);
@@ -114,7 +113,7 @@ struct ProgramConfig {
                 }},
             {"--disableStrDemux", nullptr, 0, "Disable stream demuxing",
                 [this](const char **, const ProgramArgs &a) {
-                    enableStreamDemuxing = true;
+                    enableStreamDemuxing = false;
                     return true;
                 }},
             {"--codec", nullptr, 1, "Codec to decode",
@@ -142,7 +141,7 @@ struct ProgramConfig {
                     initialWidth = std::atoi(args[0]);
                     return true;
                 }},
-            {"--initialHeight", "-l", 1, "Initial height of the video",
+            {"--initialHeight", "-h", 1, "Initial height of the video",
                 [this](const char **args, const ProgramArgs &a) {
                     initialHeight = std::atoi(args[0]);
                     return true;
@@ -159,9 +158,10 @@ struct ProgramConfig {
                     verbose = true;
                     return true;
                 }},
-            {"--noTick", nullptr, 0, "???",
+            {"--selectVideoWithComputeQueue", nullptr, 0,
+                "Select a video queue that supports compute",
                 [this](const char **args, const ProgramArgs &a) {
-                    noTick = true;
+                    selectVideoWithComputeQueue = true;
                     return true;
                 }},
             {"--noPresent", nullptr, 0,
@@ -181,7 +181,8 @@ struct ProgramConfig {
             {"--input", "-i", 1, "Input filename to decode",
                 [this](const char **args, const ProgramArgs &a) {
                     videoFileName = args[0];
-                    return true;
+                    std::ifstream validVideoFileStream(videoFileName, std::ifstream::in);
+                    return (bool)validVideoFileStream;
                 }},
             {"--output", "-o", 1, "Output filename to dump raw video to",
                 [this](const char **args, const ProgramArgs &a) {
@@ -200,10 +201,10 @@ struct ProgramConfig {
                     decoderQueueSize = std::atoi(args[0]);
                     return true;
                 }},
-            {"--computeShader", "-c", 0, "Enables post processing by running "
+            {"--computeShader", nullptr, 0, "Enables post processing by running "
                 "a compute shader on the decode output",
                 [this](const char **args, const ProgramArgs &a) {
-                    maxFrameCount = std::atoi(args[0]);
+                    enablePostProcessFilter = true;
                     return true;
                 }},
             {"--loop", nullptr, 1,
@@ -214,6 +215,12 @@ struct ProgramConfig {
                         std::cerr << "Loop count must not be negative" << std::endl;
                         return false;
                     }
+                    return true;
+                }},
+            {"--maxFrameCount", "-c", 1,
+                "Limit number of frames to be processed",
+                [this](const char **args, const ProgramArgs &a) {
+                    maxFrameCount = true;
                     return true;
                 }},
             {"--queueid", nullptr, 1, "Index of the decoder queue to be used",
@@ -317,7 +324,6 @@ struct ProgramConfig {
     uint32_t validate : 1;
     uint32_t validateVerbose : 1;
     uint32_t verbose : 1;
-    uint32_t noTick : 1;
     uint32_t noPresent : 1;
     uint32_t enableHwLoadBalancing : 1;
     uint32_t selectVideoWithComputeQueue : 1;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -89,7 +89,7 @@ static int parseArguments(EncoderConfig *encoderConfig, int argc, char *argv[])
                 fprintf(stderr, "invalid parameter for %s\n", argv[i - 1]);
                 return -1;
             }
-            if ((encoderConfig->input.numPlanes < 2) && (encoderConfig->input.numPlanes > 3)) {
+            if ((encoderConfig->input.numPlanes < 2) || (encoderConfig->input.numPlanes > 3)) {
                 fprintf(stderr, "invalid parameter for %s\n", argv[i - 1]);
                 fprintf(stderr, "Currently supported number of planes are 2 or 3\n");
             }


### PR DESCRIPTION
This performs three changes to the decoder app CLI parsing
- put the arguments in a data structure to make them available for a `--help` command
- add some additional validation for CLI parameters (missing values, values that start with `-` since likely a mistake). Please let me know if the check for arguments not starting with `-` https://github.com/nvpro-samples/vk_video_samples/pull/62/commits/57e7addf8764ff917bb036288f7787118a89a317 adds too much code and should be omitted. Without it the actual parsing code is quite short https://github.com/nvpro-samples/vk_video_samples/pull/62/commits/be1317ca494d41ea3a8fa0061d2a7844aa406498. https://docs.rs/clap/latest/clap/ performs such a check which had prevented me often to run a program with unintended CLI flags
- Remove flags `noTick` as it seems to be unused. Let me know if they are indented to be used in future.

With this refactor a bug is fixed that prevented users to select `-vv` as `strstr` would also match the `-v` option.

PS: with the recent changes to master I'm now also seeing problems with the decoder with Turing.