### PR TITLE
Encode: support separate transfer queue and generic fixes

### DIFF
--- a/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
+++ b/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
@@ -600,6 +600,11 @@ VkResult VulkanDeviceContext::CreateVulkanDevice(int32_t numDecodeQueues,
         numEncodeQueues = std::min(numEncodeQueues, m_videoEncodeNumQueues);
     }
 
+    // If no graphics, compute, or present queue is requested (i.e. for encoder app), only video
+    // queues will be created. Not all implementations support transfer on video queues.
+    const bool createTransferQueue = !(createGraphicsQueue || createPresentQueue || createComputeQueue) &&
+        !(numEncodeQueues > 0 && m_videoEncodeQueueTransferSupport);
+
     const int32_t maxQueueInstances = std::max(numDecodeQueues, numEncodeQueues);
     assert(maxQueueInstances <= MAX_QUEUE_INSTANCES);
     const std::vector<float> queuePriorities(maxQueueInstances, 0.0f);
@@ -655,6 +660,16 @@ VkResult VulkanDeviceContext::CreateVulkanDevice(int32_t numDecodeQueues,
         devInfo.queueCreateInfoCount++;
     }
 
+    if (createTransferQueue &&
+            (m_transferQueueFamily != -1) &&
+            uniqueQueueFamilies.insert(m_transferQueueFamily).second) {
+        queueInfo[devInfo.queueCreateInfoCount].sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+        queueInfo[devInfo.queueCreateInfoCount].queueFamilyIndex = m_transferQueueFamily;
+        queueInfo[devInfo.queueCreateInfoCount].queueCount = 1;
+        queueInfo[devInfo.queueCreateInfoCount].pQueuePriorities = queuePriorities.data();
+        devInfo.queueCreateInfoCount++;
+    }
+
     assert(devInfo.queueCreateInfoCount <= MAX_QUEUE_FAMILIES);
 
     devInfo.pQueueCreateInfos = queueInfo.data();
@@ -681,6 +696,9 @@ VkResult VulkanDeviceContext::CreateVulkanDevice(int32_t numDecodeQueues,
     }
     if (createPresentQueue) {
         GetDeviceQueue(m_device, GetPresentQueueFamilyIdx(), 0, &m_presentQueue);
+    }
+    if (createTransferQueue) {
+        GetDeviceQueue(m_device, GetTransferQueueFamilyIdx(), 0, &m_trasferQueue);
     }
     if (numDecodeQueues) {
         assert(GetVideoDecodeQueueFamilyIdx() != -1);

--- a/common/libs/VkCodecUtils/VulkanDeviceContext.h
+++ b/common/libs/VkCodecUtils/VulkanDeviceContext.h
@@ -74,6 +74,8 @@ public:
     VkQueue GetComputeQueue() const { return m_computeQueue; }
     int32_t GetPresentQueueFamilyIdx() const { return m_presentQueueFamily; }
     VkQueue GetPresentQueue() const { return m_presentQueue; }
+    int32_t GetTransferQueueFamilyIdx() const { return m_transferQueueFamily; }
+    VkQueue GetTransferQueue() const { return m_trasferQueue; }
     int32_t GetVideoDecodeQueueFamilyIdx() const { return m_videoDecodeQueueFamily; }
     int32_t GetVideoDecodeDefaultQueueIndex() const { return m_videoDecodeDefaultQueueIndex; }
     int32_t GetVideoDecodeNumQueues() const { return m_videoDecodeNumQueues; }
@@ -93,6 +95,7 @@ public:
     }
     bool    GetVideoDecodeQueryResultStatusSupport() const { return m_videoDecodeQueryResultStatusSupport; }
     bool    GetVideoEncodeQueryResultStatusSupport() const { return m_videoEncodeQueryResultStatusSupport; }
+    bool    GetVideoEncodeQueueTransferSupport() const { return m_videoEncodeQueueTransferSupport; }
     class MtQueueMutex {
 
     public:

--- a/vk_video_encoder/demos/vk-video-enc/Main.cpp
+++ b/vk_video_encoder/demos/vk-video-enc/Main.cpp
@@ -150,8 +150,7 @@ int main(int argc, char** argv)
                                      -1 : // all available HW encoders
                                       1;  // only one HW encoder instance
 
-    VkQueueFlags requestVideoEncodeQueueMask = VK_QUEUE_VIDEO_ENCODE_BIT_KHR |
-                                               VK_QUEUE_TRANSFER_BIT;
+    VkQueueFlags requestVideoEncodeQueueMask = VK_QUEUE_VIDEO_ENCODE_BIT_KHR;
 
     VkQueueFlags requestVideoDecodeQueueMask = 0;
     if (encoderConfig->enableVideoDecoder) {
@@ -240,7 +239,7 @@ int main(int argc, char** argv)
     } else {
 
         // No display presentation and no decoder - just the encoder
-        result = vkDevCtxt.InitPhysicalDevice((requestVideoDecodeQueueMask | requestVideoEncodeQueueMask),
+        result = vkDevCtxt.InitPhysicalDevice((requestVideoDecodeQueueMask | requestVideoEncodeQueueMask | VK_QUEUE_TRANSFER_BIT),
                                                nullptr,
                                                requestVideoDecodeQueueMask,
                                                (VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR |

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -328,6 +328,7 @@ bool EncoderConfigH264::InitSpsPpsParameters(StdVideoH264SequenceParameterSet *s
     }
 
     sps->profile_idc = profileIdc;
+    sps->level_idc = levelIdc;
 
     // constraint_setX_flag values
     sps->flags.constraint_set0_flag = profileIdc == STD_VIDEO_H264_PROFILE_IDC_BASELINE;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -108,6 +108,9 @@ struct EncoderConfigH264 : public EncoderConfig {
 
             levelLimits = levelLimitsTbl;
             levelLimitsSize = ARRAYSIZE(levelLimitsTbl);
+
+            frameRateNumerator = FRAME_RATE_NUM_DEFAULT;
+            frameRateDenominator = FRAME_RATE_DEN_DEFAULT;
     }
 
     virtual ~EncoderConfigH264() {}

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -160,8 +160,9 @@ VkResult VkVideoEncoder::SubmitStagedInputFrame(VkSharedBaseObj<VkVideoEncodeFra
     submitInfo.signalSemaphoreCount = (frameCompleteSemaphore != VK_NULL_HANDLE) ? 1 : 0;
 
     VkFence queueCompleteFence = encodeFrameInfo->inputCmdBuffer->GetFence();
-    VkResult result = m_vkDevCtx->MultiThreadedQueueSubmit(VulkanDeviceContext::ENCODE, 0,
-                                                           1, &submitInfo,
+    VkResult result = m_vkDevCtx->MultiThreadedQueueSubmit(m_vkDevCtx->GetVideoEncodeQueueTransferSupport() ?
+                                                               VulkanDeviceContext::ENCODE : VulkanDeviceContext::TRANSFER,
+                                                           0, 1, &submitInfo,
                                                            queueCompleteFence);
 
     encodeFrameInfo->inputCmdBuffer->SetCommandBufferSubmitted();
@@ -482,7 +483,9 @@ VkResult VkVideoEncoder::InitEncoder(VkSharedBaseObj<EncoderConfig>& encoderConf
 
     result = m_inputCommandBufferPool->Configure( m_vkDevCtx,
                                                   encoderConfig->numInputImages, // numPoolNodes
-                                                  m_vkDevCtx->GetVideoEncodeQueueFamilyIdx(), // queueFamilyIndex
+                                                  m_vkDevCtx->GetVideoEncodeQueueTransferSupport() ?
+                                                      m_vkDevCtx->GetVideoEncodeQueueFamilyIdx() :
+                                                      m_vkDevCtx->GetTransferQueueFamilyIdx(), // queueFamilyIndex
                                                   false,    // createQueryPool - not needed for the input transfer
                                                   nullptr,  // pVideoProfile   - not needed for the input transfer
                                                   true,     // createSemaphores


### PR DESCRIPTION
These changes were made while trying to get the encoder app working on AMD. The main change here is to support the case where video queues do not support transfer operations. The latter two generic fixes are not really functional, just to help encode more compliant streams.

@zlatinski 
