### PR TITLE
Fix windows build and correctly wait for the frame to finish decoding before outputting to file.

### DIFF
--- a/vk_video_decoder/include/vkvideo_parser/PictureBufferBase.h
+++ b/vk_video_decoder/include/vkvideo_parser/PictureBufferBase.h
@@ -64,7 +64,7 @@ public:
     vkPicBuffBase()
         : m_refCount(0)
         , m_picIdx(-1)
-        , m_displayOrder(-1)
+        , m_displayOrder((uint32_t)-1)
         , m_decodeOrder(0)
         , m_timestamp(0)
         , m_presentTime(0)


### PR DESCRIPTION
Fixes a warning that turns into an error on MSVCs.

Fixes an issue with waiting for fences when the first wait times out.