### PR TITLE
decoder: only create compute queue when requested

### DIFF
--- a/vk_video_decoder/demos/vk-video-dec/Main.cpp
+++ b/vk_video_decoder/demos/vk-video-dec/Main.cpp
@@ -211,7 +211,7 @@ int main(int argc, const char **argv) {
                                      false, //  createTransferQueue
                                      true,  // createGraphicsQueue
                                      true,  // createDisplayQueue
-                                     true   // createComputeQueue
+                                     requestVideoComputeQueueMask != 0  // createComputeQueue
                                      );
         vulkanVideoProcessor->Initialize(&vkDevCtxt, programConfig);
 
@@ -239,7 +239,7 @@ int main(int argc, const char **argv) {
                                               ((vkDevCtxt.GetVideoDecodeQueueFlag() & VK_QUEUE_TRANSFER_BIT) == 0), //  createTransferQueue
                                               false, // createGraphicsQueue
                                               false, // createDisplayQueue
-                                              true   // createComputeQueue
+                                              requestVideoComputeQueueMask != 0   // createComputeQueue
                                               );
         if (result != VK_SUCCESS) {
 


### PR DESCRIPTION
If a compute queue isn't requested at InitPhysicalDevice() time, the queue family for compute won't be retrieved. Then if createComputeQueue is set in CreateVulkanDevice, vkGetDeviceQueue will be called with queueFamilyIndex = -1.