### PR TITLE
AV1 decode: fix apply_grain for invisible frames

### DIFF
--- a/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
@@ -1114,6 +1114,7 @@ bool VulkanAV1Decoder::ReadFilmGrainParams()
         pFilmGrain->flags.overlap_flag = u(1);
         pFilmGrain->flags.clip_to_restricted_range = u(1);
     } else {
+        pStd->flags.apply_grain = 0;
         memset(pFilmGrain, 0, sizeof(StdVideoAV1FilmGrain));
     }
 


### PR DESCRIPTION
An invisible frame (neither shown nor showable) falls into this case in the AV1 specification 5.9.30:

```
if ( !film_grain_params_present ||
     (!show_frame && !showable_frame) ) {
    reset_grain_params()
    return
}
```

6.8.20: "reset_grain_params() is a function call that indicates that all the syntax elements read in film_grain_params should be set equal to 0."

Hence `apply_grain` should be zero in this case.