### PR TITLE
CRC support and Y4M support

### DIFF
--- a/common/libs/VkCodecUtils/VulkanVideoProcessor.h
+++ b/common/libs/VkCodecUtils/VulkanVideoProcessor.h
@@ -36,7 +36,7 @@ public:
 
     static VkSharedBaseObj<VulkanVideoProcessor>& invalidVulkanVideoProcessor;
 
-    static VkResult Create(const VulkanDeviceContext* vkDevCtx,
+    static VkResult Create(const ProgramConfig& settings, const VulkanDeviceContext* vkDevCtx,
                            VkSharedBaseObj<VulkanVideoProcessor>& vulkanVideoProcessor = invalidVulkanVideoProcessor);
 
     int32_t Initialize(const VulkanDeviceContext* vkDevCtx, ProgramConfig& programConfig);
@@ -67,7 +67,7 @@ public:
 
 private:
 
-    VulkanVideoProcessor(const VulkanDeviceContext* vkDevCtx)
+    VulkanVideoProcessor(const ProgramConfig& settings, const VulkanDeviceContext* vkDevCtx)
         : m_refCount(0),
           m_vkDevCtx(vkDevCtx),
           m_videoStreamDemuxer()
@@ -83,6 +83,7 @@ private:
         , m_loopCount(1)
         , m_startFrame(0)
         , m_maxFrameCount(-1)
+        , m_settings(settings)
     {
     }
 
@@ -98,11 +99,12 @@ private:
                                   size_t* pnVideoBytes = nullptr,
                                   bool doPartialParsing = false,
                                   uint32_t flags = 0, int64_t timestamp = 0);
-    size_t ConvertFrameToNv12(VulkanDecodedFrame* pFrame, VkSharedBaseObj<VkImageResource>& imageResource,
-                              uint8_t* pOutputBuffer, size_t bufferSize);
-
 
     bool StreamCompleted();
+
+private:
+    void WaitForFrameCompletion(VulkanDecodedFrame* pFrame, 
+                                VkSharedBaseObj<VkImageResource>& imageResource);
 
 private:
     std::atomic<int32_t>       m_refCount;
@@ -120,6 +122,7 @@ private:
     int32_t   m_loopCount;
     uint32_t  m_startFrame;
     int32_t   m_maxFrameCount;
+    const ProgramConfig& m_settings;
 };
 
 #endif /* _VULKANVIDEOPROCESSOR_H_ */

--- a/vk_video_decoder/demos/vk-video-dec/CMakeLists.txt
+++ b/vk_video_decoder/demos/vk-video-dec/CMakeLists.txt
@@ -73,6 +73,7 @@ set(sources
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/nvVkFormats.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanBistreamBufferImpl.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanBistreamBufferImpl.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/crcgenerator.cpp
     ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkDecoderUtils/FFmpegDemuxer.cpp
     ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkDecoderUtils/VideoStreamDemuxer.cpp
     ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkDecoderUtils/VideoStreamDemuxer.h


### PR DESCRIPTION
Allows the sample app to produce CRCs per frame and for the entire file for decode. The following commandline parameters have been added:
 --crc
 --crcframe
 --crcinit
 --y4m

Fixed --c to actually accept a max frame count instead of silently accepting a bolean as an inteteger..