### PR TITLE
H264RateControl: do not force the rate control for default

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -478,11 +478,7 @@ bool EncoderConfigH264::GetRateControlParameters(VkVideoEncodeRateControlInfoKHR
     pRateControlLayersInfo->frameRateNumerator = frameRateNumerator;
     pRateControlLayersInfo->frameRateDenominator = frameRateDenominator;
 
-    if (rateControlMode == VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DEFAULT_KHR) {
-        pRateControlInfo->rateControlMode = VK_VIDEO_ENCODE_RATE_CONTROL_MODE_VBR_BIT_KHR;
-    } else {
-        pRateControlInfo->rateControlMode = rateControlMode;
-    }
+    pRateControlInfo->rateControlMode = rateControlMode;
 
     if (pRateControlInfo->rateControlMode == VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR) {
         pRateControlLayerInfoH264->minQp = pRateControlLayerInfoH264->maxQp = minQp;


### PR DESCRIPTION
Intel ANV does not support VBR rate control so keep default rate control selected by the config.