### PR TITLE
decoder: Fix file output for DISTINCT DPB case

### DIFF
--- a/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
+++ b/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
@@ -352,10 +352,10 @@ int32_t VkVideoDecoder::StartVideoSequence(VkParserDetectedVideoFormat* pVideoFo
     if ((m_enableDecodeComputeFilter == VK_FALSE) && (m_useLinearOutput == VK_TRUE)) {
 
         // If the compute filter is not enabled and we need linear images
-        // Use a transfer operation to copy the decoder's output to a linear image.
-        m_useTransferOperation = VK_TRUE;
 
         if (m_dpbAndOutputCoincide == VK_TRUE) {
+            // Use a transfer operation to copy the decoder's output to a linear image.
+            m_useTransferOperation = VK_TRUE;
 
             // We need an extra image for the filter output for coincide - linear or optimal image
             m_imageSpecsIndex.linearOut = imageSpecsIndex++;

--- a/vk_video_decoder/libs/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.cpp
+++ b/vk_video_decoder/libs/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.cpp
@@ -504,6 +504,10 @@ public:
 
             {
                 uint8_t linearOutImageType = m_perFrameDecodeImageSet[pictureIndex].m_imageSpecsIndex.linearOut;
+                if (linearOutImageType == InvalidImageTypeIdx) {
+                    linearOutImageType = m_perFrameDecodeImageSet[pictureIndex].m_imageSpecsIndex.decodeOut;
+                }
+
                 if (m_perFrameDecodeImageSet[pictureIndex].ImageExist(linearOutImageType)) {
                     pDecodedFrame->imageViews[VulkanDisplayFrame::IMAGE_VIEW_TYPE_LINEAR].view = m_perFrameDecodeImageSet[pictureIndex].GetImageView(linearOutImageType);
                     pDecodedFrame->imageViews[VulkanDisplayFrame::IMAGE_VIEW_TYPE_LINEAR].singleLevelView = m_perFrameDecodeImageSet[pictureIndex].GetSingleLevelImageView(linearOutImageType);


### PR DESCRIPTION
My thought here is that the transfer operation doesn't have to be done in the distinct case (since its allocated as linear already), so only set `m_useTransferOperation = true` in the coincide mode. Then the `VkVideoFrameBuffer` needs to provide the decode output image views for `IMAGE_VIEW_TYPE_LINEAR`.

Without this change, outputting to a file on a DISTINCT DPB implementation would have caused a crash, since the copy operation would have been attempted with the `dstImage` being NULL.

This still relies on the assumption that a distinct output for decoder images supports linear tiling.

@zlatinski: I'm not sure if this is the proper fix, as I don't fully understand what the image specs and such are supposed to do.