### PR TITLE
EncoderConfig: add input file get frame count

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -133,6 +133,7 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
     int argcount = 0;
     std::vector<char*> arglist;
     std::vector<std::string> args(argv, argv + argc);
+    uint32_t frameCount = 0;
 
     appName = args[0];
 
@@ -522,6 +523,19 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
     if (enableQpMap && !qpMapFileHandler.HasFileName()) {
         fprintf(stderr, "No qpMap file was provided.");
         return -1;
+    }
+
+    frameCount = inputFileHandler.GetFrameCount(input.width, input.height, input.bpp, input.chromaSubsampling);
+
+    if (numFrames == 0 || numFrames > frameCount) {
+        std::cout << "numFrames " << numFrames
+                  <<  " should be different from zero and inferior to input file frame count: "
+                  << frameCount << ". Use input file frame count." << std::endl;
+        numFrames = frameCount;
+        if (numFrames == 0) {
+            fprintf(stderr, "No frames found in the input file, frame count is zero. Exit.");
+            return -1;
+        }
     }
 
     return DoParseArguments(argcount, arglist.data());

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -389,6 +389,25 @@ beach:
         return i + 1;
     }
 
+    uint32_t GetFrameCount(uint32_t width, uint32_t height, uint8_t bpp, VkVideoChromaSubsamplingFlagBitsKHR chromaSubsampling) {
+        uint8_t nBytes = (uint8_t)std::ceil ( bpp / 8);
+        double samplingFactor = 1.5;
+        switch (chromaSubsampling)
+        {
+        case VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR:
+            samplingFactor = 1.5;
+            break;
+        default:
+            break;
+        }
+        uint32_t frameSize = (uint32_t)(width * height * nBytes * samplingFactor);
+
+        if(frameSize)
+            return (uint32_t)(GetFileSize()/frameSize);
+
+        return 0;
+    }
+
 private:
     size_t OpenFile()
     {


### PR DESCRIPTION
In case user does not specify --numFrames, the gopFrameCount was zero and causing a crash.
If user does not specify the numFrames, the number of frames in the input file should be used.