### PR TITLE
EncoderConfigAV1: Fix GetMaxBFrameCount

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
@@ -117,6 +117,8 @@ struct EncoderConfigAV1 : public EncoderConfig {
 
     virtual bool InitRateControl() override;
 
+    virtual uint8_t GetMaxBFrameCount() { return  static_cast<uint8_t>(av1EncodeCapabilities.maxBidirectionalCompoundReferenceCount); }
+
     bool GetRateControlParameters(VkVideoEncodeRateControlInfoKHR* rcInfo,
                                   VkVideoEncodeRateControlLayerInfoKHR* rcLayerInfo,
                                   VkVideoEncodeAV1RateControlInfoKHR* rcInfoAV1,


### PR DESCRIPTION
To support driver which does not support B Frame,
GetMaxBFrameCount has been introduced in
https://github.com/nvpro-samples/vk_video_samples/pull/103 but AV1 was not supported yet.