### PR TITLE
Added initial version of the transcoding

### DIFF
--- a/common/include/VkVideoCore/VkVideoCoreProfile.h
+++ b/common/include/VkVideoCore/VkVideoCoreProfile.h
@@ -193,7 +193,16 @@ public:
                           VkVideoComponentBitDepthFlagsKHR lumaBitDepth = VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR,
                           VkVideoComponentBitDepthFlagsKHR chromaBitDepth = VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR,
                           uint32_t videoH26xProfileIdc = 0,
-                          VkVideoEncodeTuningModeKHR tuningMode = VK_VIDEO_ENCODE_TUNING_MODE_DEFAULT_KHR)
+#if (_TRANSCODING)
+                          VkVideoEncodeUsageInfoKHR encodeUsageInfo = {VK_STRUCTURE_TYPE_VIDEO_ENCODE_USAGE_INFO_KHR,
+                                                         NULL,
+                                                         VK_VIDEO_ENCODE_CONTENT_DEFAULT_KHR,
+                                                         VK_VIDEO_ENCODE_USAGE_DEFAULT_KHR,
+                                                         VK_VIDEO_ENCODE_TUNING_MODE_DEFAULT_KHR }
+#else
+                          VkVideoEncodeTuningModeKHR tuningMode = VK_VIDEO_ENCODE_TUNING_MODE_DEFAULT_KHR
+#endif // _TRANSCODING
+    )
         : m_profile({VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR, NULL,
                      videoCodecOperation, chromaSubsampling, lumaBitDepth, chromaBitDepth}),
           m_profileList({VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR, NULL, 1, &m_profile})
@@ -210,8 +219,12 @@ public:
         VkVideoEncodeAV1ProfileInfoKHR encodeAV1ProfilesRequest;
         VkBaseInStructure* pVideoProfileExt = NULL;
 
+#if (_TRANSCODING)
+        VkVideoEncodeUsageInfoKHR encodeUsageInfoRequest = encodeUsageInfo;
+#else
         VkVideoEncodeUsageInfoKHR encodeUsageInfoRequest{VK_STRUCTURE_TYPE_VIDEO_ENCODE_USAGE_INFO_KHR,
                                                          NULL, 0, 0, tuningMode};
+#endif // _TRANSCODING
         VkBaseInStructure* pEncodeUsageInfo = (VkBaseInStructure*)&encodeUsageInfoRequest;
 
         if (videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR) {

--- a/common/libs/VkCodecUtils/FrameProcessor.h
+++ b/common/libs/VkCodecUtils/FrameProcessor.h
@@ -25,6 +25,12 @@
 
 #include "VkCodecUtils/VkVideoRefCountBase.h"
 #include "VkCodecUtils/ProgramConfig.h"
+#if (_TRANSCODING)
+#include "VkCodecUtils/VulkanDecodedFrame.h"
+#include "VkCodecUtils/VulkanEncoderFrameProcessor.h"
+#include "VkCodecUtils/ProgramConfig.h"
+#include "VkVideoEncoder/VkEncoderConfig.h"
+#endif // _TRANSCODING
 
 class Shell;
 
@@ -65,6 +71,16 @@ public:
                          const VkSemaphore* pWaitSemaphores  = nullptr,
                          uint32_t           signalSemaphoreCount = 0,
                          const VkSemaphore* pSignalSemaphores = nullptr) = 0;
+#if (_TRANSCODING)
+    virtual bool OnFrameTranscoding( int32_t renderIndex,
+                         ProgramConfig* programConfig,
+                         VkSharedBaseObj<EncoderConfig>& encoderConfig,
+                         uint32_t           waitSemaphoreCount = 0,
+                         const VkSemaphore* pWaitSemaphores  = nullptr,
+                         uint32_t           signalSemaphoreCount = 0,
+                         const VkSemaphore* pSignalSemaphores = nullptr,
+                         VulkanDecodedFrame* pLastFrameDecoded = nullptr) = 0;
+#endif // _TRANSCODING
 
     uint64_t GetTimeDiffNanoseconds(bool updateStartTime = true)
     {

--- a/common/libs/VkCodecUtils/HelpersDispatchTable.cpp
+++ b/common/libs/VkCodecUtils/HelpersDispatchTable.cpp
@@ -98,6 +98,9 @@ void InitDispatchTableMiddle(VkInstance instance, bool include_bottom, VkInterfa
 #ifdef VK_USE_VIDEO_QUEUE
     pVkFunctions->GetPhysicalDeviceVideoCapabilitiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceVideoCapabilitiesKHR>(getInstanceProcAddrFunc(instance, "vkGetPhysicalDeviceVideoCapabilitiesKHR"));
 #endif
+#ifdef VK_USE_VIDEO_QUEUE
+    pVkFunctions->GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR>(getInstanceProcAddrFunc(instance, "vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR"));
+#endif
 
     if (!include_bottom)
         return;

--- a/common/libs/VkCodecUtils/HelpersDispatchTable.h
+++ b/common/libs/VkCodecUtils/HelpersDispatchTable.h
@@ -277,6 +277,7 @@ struct VkInterfaceFunctions {
 // VK_KHR_video_queue
     PFN_vkGetPhysicalDeviceVideoFormatPropertiesKHR GetPhysicalDeviceVideoFormatPropertiesKHR;
     PFN_vkGetPhysicalDeviceVideoCapabilitiesKHR GetPhysicalDeviceVideoCapabilitiesKHR;
+    PFN_vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR;
     PFN_vkCreateVideoSessionKHR CreateVideoSessionKHR;
     PFN_vkDestroyVideoSessionKHR DestroyVideoSessionKHR;
     PFN_vkCreateVideoSessionParametersKHR CreateVideoSessionParametersKHR;

--- a/common/libs/VkCodecUtils/ProgramConfig.h
+++ b/common/libs/VkCodecUtils/ProgramConfig.h
@@ -109,7 +109,9 @@ struct ProgramConfig {
             {"--help", nullptr, 0, "Show this help",
                 [argv](const char **, const ProgramArgs &a) {
                     int rtn = showHelp(argv, a);
+#if (!_TRANSCODING) // transcoding: should print encode info as well
                     exit(EXIT_SUCCESS);
+#endif // !_TRANSCODING
                     return rtn;
                 }},
             {"--enableStrDemux", nullptr, 0, "Enable stream demuxing",
@@ -122,7 +124,12 @@ struct ProgramConfig {
                     enableStreamDemuxing = false;
                     return true;
                 }},
-            {"--codec", nullptr, 1, "Codec to decode",
+                {
+#if (!_TRANSCODING) // transcoding: to prevent overlap with encoder's codec option
+            "--codec", nullptr, 1, "Codec to decode",
+#else
+            "--codec-input", nullptr, 1, "Codec to decode",
+#endif // !_TRANSCODING
                 [this](const char **args, const ProgramArgs &a) {
                     if ((strcmp(args[0], "hevc") == 0) ||
                         (strcmp(args[0], "h265") == 0)) {
@@ -330,10 +337,15 @@ struct ProgramConfig {
                 (a.short_flag != nullptr && strcmp(argv[i], a.short_flag) == 0);
             });
             if (flag == spec.end()) {
+#if (!_TRANSCODING) // transcoding: should parse encode info after decode info as well
                 std::cerr << "Unknown argument \"" << argv[i] << "\"" << std::endl;
                 std::cout << std::endl;
+                continue;
                 showHelp(argv, spec);
                 exit(EXIT_FAILURE);
+#else
+                continue;
+#endif // !_TRANSCODING
             }
 
             if (i + flag->numArgs >= argc) {

--- a/common/libs/VkCodecUtils/VkImageResource.h
+++ b/common/libs/VkCodecUtils/VkImageResource.h
@@ -141,7 +141,7 @@ public:
     }
 
     operator VkImageView() const { return m_imageViews[0]; }
-    VkImageView GetImageView() const { return m_imageViews[0]; }
+    VkImageView GetImageView(int i = 0) const { return m_imageViews[i]; }
     uint32_t GetNumberOfPlanes() const { return m_numPlanes; }
     VkImageView GetPlaneImageView(uint32_t planeIndex = 0) const { assert(planeIndex < m_numPlanes);  return m_imageViews[planeIndex + 1]; }
     VkDevice GetDevice() const { return *m_vkDevCtx; }

--- a/common/libs/VkCodecUtils/VkVideoQueue.h
+++ b/common/libs/VkCodecUtils/VkVideoQueue.h
@@ -18,6 +18,10 @@
 #define _VKCODECUTILS_VKVIDEOQUEUE_H_
 
 #include "VkCodecUtils/VkVideoRefCountBase.h"
+#if (_TRANSCODING)
+#include "VkCodecUtils/ProgramConfig.h"
+#include "VkVideoEncoder/VkEncoderConfig.h"
+#endif // _TRANSCODING
 
 template<class FrameDataType>
 class VkVideoQueue : public VkVideoRefCountBase {
@@ -30,7 +34,11 @@ public:
     virtual VkFormat GetFrameImageFormat(int32_t* pWidth = nullptr,
                                          int32_t* pHeight = nullptr,
                                          int32_t* pBitDepth = nullptr) const = 0;
-    virtual int32_t GetNextFrame(FrameDataType* pFrame, bool* endOfStream) = 0;
+    virtual int32_t GetNextFrame(FrameDataType* pFrame, bool* endOfStream
+#if (_TRANSCODING)
+    , ProgramConfig* programConfig = nullptr, VkSharedBaseObj<EncoderConfig>* encoderConfig = nullptr
+#endif // _TRANSCODING
+    ) = 0;
     virtual int32_t ReleaseFrame(FrameDataType* pDisplayedFrame) = 0;
 public:
     virtual ~VkVideoQueue() {};

--- a/common/libs/VkCodecUtils/VulkanFrame.cpp
+++ b/common/libs/VkCodecUtils/VulkanFrame.cpp
@@ -26,6 +26,9 @@
 #include "VulkanFrame.h"
 #include "vk_enum_string_helper.h"
 #include "VkVideoCore/DecodeFrameBufferIf.h"
+#if (_TRANSCODING)
+#include "VkVideoEncoder/VkVideoEncoder.h"
+#endif // _TRANSCODING
 
 template<class FrameDataType>
 VulkanFrame<FrameDataType>::VulkanFrame(const VulkanDeviceContext* vkDevCtx,
@@ -270,6 +273,39 @@ bool VulkanFrame<FrameDataType>::OnKey(Key key)
     return true;
 }
 
+#if (_TRANSCODING)
+static int InitPreset(VkSharedBaseObj<EncoderConfig>& encoderConfig)
+{
+    if (encoderConfig->codec == VkVideoCodecOperationFlagBitsKHR::VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR) encoderConfig->qualityLevel = 0;
+
+    if (encoderConfig->encodingProfile == EncoderConfig::LOW_LATENCY_STREAMING)
+    {
+        encoderConfig->rateControlMode = VkVideoEncodeRateControlModeFlagBitsKHR::VK_VIDEO_ENCODE_RATE_CONTROL_MODE_CBR_BIT_KHR;
+        encoderConfig->gopStructure.SetConsecutiveBFrameCount(0);
+        encoderConfig->gopStructure.SetGopFrameCount((uint16_t)-1);
+        encoderConfig->gopStructure.SetIdrPeriod((uint16_t)-1);
+        encoderConfig->gopStructure.SetLastFrameType(VkVideoGopStructure::FrameType::FRAME_TYPE_P); // ? set right value
+        encoderConfig->encodeUsageHints = VK_VIDEO_ENCODE_USAGE_STREAMING_BIT_KHR;
+        encoderConfig->encodeContentHints = VK_VIDEO_ENCODE_CONTENT_RENDERED_BIT_KHR;
+        encoderConfig->tuningMode = VK_VIDEO_ENCODE_TUNING_MODE_ULTRA_LOW_LATENCY_KHR;
+        // encoderConfig->gopStructure.SetTemporalLayerCount(3);
+    }
+    else if (encoderConfig->encodingProfile == EncoderConfig::ARCHIVING)
+    {
+        encoderConfig->rateControlMode = VkVideoEncodeRateControlModeFlagBitsKHR::VK_VIDEO_ENCODE_RATE_CONTROL_MODE_VBR_BIT_KHR;
+        encoderConfig->maxBitrate = (uint32_t)(1.2f * encoderConfig->averageBitrate); // This is used in Variable Bit Rate (VBR) mode and is ignored for Constant Bit Rate (CBR) mode.
+        encoderConfig->gopStructure.SetConsecutiveBFrameCount(3);
+        encoderConfig->gopStructure.SetIdrPeriod(MAX_GOP_SIZE);
+        encoderConfig->gopStructure.SetGopFrameCount(MAX_GOP_SIZE);
+        encoderConfig->gopStructure.SetTemporalLayerCount(1);
+        encoderConfig->encodeUsageHints = VK_VIDEO_ENCODE_USAGE_RECORDING_BIT_KHR;
+        encoderConfig->encodeContentHints = VK_VIDEO_ENCODE_CONTENT_RENDERED_BIT_KHR;
+        encoderConfig->tuningMode = VK_VIDEO_ENCODE_TUNING_MODE_HIGH_QUALITY_KHR;
+    };
+    return 0;
+}
+#endif // _TRANSCODING
+
 template<class FrameDataType>
 bool VulkanFrame<FrameDataType>::OnFrame( int32_t renderIndex,
                           uint32_t           waitSemaphoreCount,
@@ -394,6 +430,7 @@ bool VulkanFrame<FrameDataType>::OnFrame( int32_t renderIndex,
                                 pSignalSemaphores,
                                 pLastDecodedFrame);
 
+    // VkImageLastDecodedFrame()
 
     if (VK_SUCCESS != result) {
         return false;
@@ -401,6 +438,143 @@ bool VulkanFrame<FrameDataType>::OnFrame( int32_t renderIndex,
 
     return continueLoop;
 }
+
+#if (_TRANSCODING)
+template<class FrameDataType>
+bool VulkanFrame<FrameDataType>::OnFrameTranscoding( int32_t renderIndex,
+                          ProgramConfig* programConfig,
+                          VkSharedBaseObj<EncoderConfig>& encoderConfig,
+                          uint32_t           waitSemaphoreCount,
+                          const VkSemaphore* pWaitSemaphores,
+                          uint32_t           signalSemaphoreCount,
+                          const VkSemaphore* pSignalSemaphores,
+                          VulkanDecodedFrame* pLastDecodedFrameRet)
+{
+    // must not be used by encoder
+    int isFunctionUsed = 0;
+    isFunctionUsed++;
+    assert(isFunctionUsed == 0);//, "must not be used by encoder");
+    return false;
+}
+
+template<>
+bool VulkanFrame<VulkanDecodedFrame>::OnFrameTranscoding( int32_t renderIndex,
+                          ProgramConfig* programConfig,
+                          VkSharedBaseObj<EncoderConfig>& encoderConfig,
+                          uint32_t           waitSemaphoreCount,
+                          const VkSemaphore* pWaitSemaphores,
+                          uint32_t           signalSemaphoreCount,
+                          const VkSemaphore* pSignalSemaphores,
+                          VulkanDecodedFrame* pLastDecodedFrameRet)
+{
+    InitPreset(encoderConfig);
+    bool continueLoop = true;
+    const bool dumpDebug = false;
+    const bool trainFrame = (renderIndex < 0);
+    const bool gfxRendererIsEnabled = (m_videoRenderer != nullptr);
+    m_frameCount++;
+
+    if (dumpDebug == false) {
+        bool displayTimeNow = false;
+        float fps = GetFrameRateFps(displayTimeNow);
+        if (displayTimeNow) {
+            std::cout << "\t\tFrame " << m_frameCount << ", FPS: " << fps << std::endl;
+        }
+    } else {
+        uint64_t timeDiffNanoSec = GetTimeDiffNanoseconds();
+        std::cout << "\t\t Time nanoseconds: " << timeDiffNanoSec <<
+                     " milliseconds: " << timeDiffNanoSec / 1000 <<
+                     " rate: " << 1000000000.0 / timeDiffNanoSec << std::endl;
+    }
+
+    VulkanDecodedFrame* pLastDecodedFrame = nullptr;
+    // FrameDataType* pLastDecodedFrame = nullptr;
+
+    if (m_videoQueue->IsValid() && !trainFrame) {
+
+        pLastDecodedFrame = &m_frameData[m_frameDataIndex];
+
+        // Graphics and present stages are not enabled.
+        // Make sure the frame complete query or fence are signaled (video frame is processed) before returning the frame.
+        if (false && (gfxRendererIsEnabled == false) && (pLastDecodedFrame != nullptr)) {
+
+            if (pLastDecodedFrame->queryPool != VK_NULL_HANDLE) {
+                auto startTime = std::chrono::steady_clock::now();
+                VkQueryResultStatusKHR decodeStatus;
+                VkResult result = m_vkDevCtx->GetQueryPoolResults(*m_vkDevCtx,
+                                                 pLastDecodedFrame->queryPool,
+                                                 pLastDecodedFrame->startQueryId,
+                                                 1,
+                                                 sizeof(decodeStatus),
+                                                 &decodeStatus,
+                                                 sizeof(decodeStatus),
+                                                 VK_QUERY_RESULT_WITH_STATUS_BIT_KHR | VK_QUERY_RESULT_WAIT_BIT);
+
+                assert(result == VK_SUCCESS);
+                assert(decodeStatus == VK_QUERY_RESULT_STATUS_COMPLETE_KHR);
+                auto deltaTime = std::chrono::steady_clock::now() - startTime;
+                auto diffMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(deltaTime);
+                auto diffMicroseconds = std::chrono::duration_cast<std::chrono::microseconds>(deltaTime);
+                if (dumpDebug) {
+                    std::cout << pLastDecodedFrame->pictureIndex << ": frameWaitTime: " <<
+                                 diffMilliseconds.count() << "." << diffMicroseconds.count() << " mSec" << std::endl;
+                }
+            } else if (pLastDecodedFrame->frameCompleteFence != VkFence()) {
+                VkResult result = m_vkDevCtx->WaitForFences(*m_vkDevCtx, 1, &pLastDecodedFrame->frameCompleteFence, true, 100 * 1000 * 1000 /* 100 mSec */);
+                assert(result == VK_SUCCESS);
+                if (result != VK_SUCCESS) {
+                    fprintf(stderr, "\nERROR: WaitForFences() result: 0x%x\n", result);
+                }
+                result = m_vkDevCtx->GetFenceStatus(*m_vkDevCtx, pLastDecodedFrame->frameCompleteFence);
+                assert(result == VK_SUCCESS);
+                if (result != VK_SUCCESS) {
+                    fprintf(stderr, "\nERROR: GetFenceStatus() result: 0x%x\n", result);
+                }
+            }
+        }
+
+        m_videoQueue->ReleaseFrame(pLastDecodedFrame);
+
+        pLastDecodedFrame->Reset();
+
+        bool endOfStream = false;
+        int32_t numVideoFrames = 0;
+
+        if (pLastDecodedFrame) {
+            numVideoFrames = m_videoQueue->GetNextFrame(pLastDecodedFrame, &endOfStream, programConfig, &encoderConfig);
+        }
+        if (endOfStream && (numVideoFrames < 0)) {
+            continueLoop = false;
+            bool displayTimeNow = true;
+            float fps = GetFrameRateFps(displayTimeNow);
+            if (displayTimeNow) {
+                std::cout << "\t\tFrame " << m_frameCount << ", FPS: " << fps << std::endl;
+            }
+        }
+    }
+
+    if (gfxRendererIsEnabled == false) {
+        m_frameDataIndex = (m_frameDataIndex + 1) % m_frameData.size();
+        return continueLoop;
+    }
+
+    VkResult result = DrawFrame(renderIndex,
+                                waitSemaphoreCount,
+                                pWaitSemaphores,
+                                signalSemaphoreCount,
+                                pSignalSemaphores,
+                                pLastDecodedFrame);
+
+    // VkImageLastDecodedFrame()
+
+
+    if (VK_SUCCESS != result) {
+        return false;
+    }
+
+    return continueLoop;
+}
+#endif // _TRANSCODING
 
 template<class FrameDataType>
 VkResult VulkanFrame<FrameDataType>::DrawFrame( int32_t            renderIndex,

--- a/common/libs/VkCodecUtils/VulkanFrame.h
+++ b/common/libs/VkCodecUtils/VulkanFrame.h
@@ -63,6 +63,16 @@ public:
                           uint32_t           signalSemaphoreCount = 0,
                           const VkSemaphore* pSignalSemaphores = nullptr);
 
+#if (_TRANSCODING)
+    virtual bool OnFrameTranscoding(int32_t  renderIndex,
+                          ProgramConfig* programConfig,
+                          VkSharedBaseObj<EncoderConfig>& encoderConfig,
+                          uint32_t           waitSemaphoreCount = 0,
+                          const VkSemaphore* pWaitSemaphores  = nullptr,
+                          uint32_t           signalSemaphoreCount = 0,
+                          const VkSemaphore* pSignalSemaphores = nullptr,
+                          VulkanDecodedFrame* pLastFrameDecoded = nullptr);
+#endif // _TRANSCODING
 
     VkResult DrawFrame( int32_t           renderIndex,
                        uint32_t           waitSemaphoreCount,

--- a/common/libs/VkCodecUtils/VulkanVideoDisplayQueue.h
+++ b/common/libs/VkCodecUtils/VulkanVideoDisplayQueue.h
@@ -22,6 +22,10 @@
 #include <condition_variable>
 #include "VkCodecUtils/VkVideoQueue.h"
 #include "VkCodecUtils/VkThreadSafeQueue.h"
+#if (_TRANSCODING)
+#include "VkCodecUtils/ProgramConfig.h"
+#include "VkVideoEncoder/VkEncoderConfig.h"
+#endif // _TRANSCODING
 
 template<class FrameDataType>
 class VulkanVideoDisplayQueue : public VkVideoQueue<FrameDataType> {
@@ -33,7 +37,11 @@ public:
     virtual int32_t GetBitDepth() const { return m_defaultBitDepth; }
     virtual VkFormat GetFrameImageFormat(int32_t* pWidth = NULL, int32_t* pHeight = NULL,
                                          int32_t* pBitDepth = NULL)  const;
-    virtual int32_t GetNextFrame(FrameDataType* pFrame, bool* endOfStream);
+    virtual int32_t GetNextFrame(FrameDataType* pFrame, bool* endOfStream
+#if (_TRANSCODING)
+    , ProgramConfig* programConfig, VkSharedBaseObj<EncoderConfig>* encoderConfig
+#endif // _TRANSCODING
+);
     virtual int32_t ReleaseFrame(FrameDataType* pDisplayedFrame);
 
     static VkSharedBaseObj<VulkanVideoDisplayQueue>& invalidVulkanVideoDisplayQueue;
@@ -173,7 +181,11 @@ int32_t VulkanVideoDisplayQueue<FrameDataType>::EnqueueFrame(FrameDataType* pFra
 }
 
 template<class FrameDataType>
-int32_t VulkanVideoDisplayQueue<FrameDataType>::GetNextFrame(FrameDataType* pFrame, bool* endOfStream)
+int32_t VulkanVideoDisplayQueue<FrameDataType>::GetNextFrame(FrameDataType* pFrame, bool* endOfStream
+#if (_TRANSCODING)
+    , ProgramConfig* programConfig, VkSharedBaseObj<EncoderConfig>* encoderConfig
+#endif // _TRANSCODING
+)
 {
     if (m_exitQueueRequested) {
         m_queue.SetFlushAndExit();

--- a/common/libs/VkCodecUtils/VulkanVideoProcessor.h
+++ b/common/libs/VkCodecUtils/VulkanVideoProcessor.h
@@ -23,6 +23,10 @@
 #include "VkCodecUtils/ProgramConfig.h"
 #include "VkCodecUtils/VkVideoQueue.h"
 
+#if (_TRANSCODING)
+#include "VkVideoEncoder/VkVideoEncoder.h"
+#endif //_TRANSCODING
+
 class VulkanVideoProcessor : public VkVideoQueue<VulkanDecodedFrame> {
 public:
 
@@ -30,8 +34,18 @@ public:
     virtual int32_t GetWidth()    const;
     virtual int32_t GetHeight()   const;
     virtual int32_t GetBitDepth() const;
+#if (_TRANSCODING)
+    virtual int32_t GetCodedWidth()    const;
+    virtual int32_t GetCodedHeight()   const;
+    virtual uint32_t GetFrameRate() const;
+    virtual uint32_t GetFramesCount() const;
+#endif // _TRANSCODING
     virtual VkFormat GetFrameImageFormat(int32_t* pWidth = NULL, int32_t* pHeight = NULL, int32_t* pBitDepth = NULL)  const;
-    virtual int32_t GetNextFrame(VulkanDecodedFrame* pFrame, bool* endOfStream);
+    virtual int32_t GetNextFrame(VulkanDecodedFrame* pFrame, bool* endOfStream
+#if (_TRANSCODING)
+    , ProgramConfig* programConfig = nullptr, VkSharedBaseObj<EncoderConfig>* encoderConfig = nullptr
+#endif // _TRANSCODING
+);
     virtual int32_t ReleaseFrame(VulkanDecodedFrame* pDisplayedFrame);
 
     static VkSharedBaseObj<VulkanVideoProcessor>& invalidVulkanVideoProcessor;
@@ -73,6 +87,9 @@ private:
           m_videoStreamDemuxer()
         , m_vkVideoFrameBuffer()
         , m_vkVideoDecoder()
+#if (_TRANSCODING)
+        , m_vkVideoEncoder()
+#endif // _TRANSCODING
         , m_vkParser()
         , m_currentBitstreamOffset(0)
         , m_videoFrameNum(0)
@@ -102,6 +119,13 @@ private:
 
     bool StreamCompleted();
 
+#if (_TRANSCODING)
+public:
+    VkSharedBaseObj<VkVideoEncoder> getEncoder() const {
+        return m_vkVideoEncoder;
+    };
+#endif // _TRANSCODING
+
 private:
     void WaitForFrameCompletion(VulkanDecodedFrame* pFrame, 
                                 VkSharedBaseObj<VkImageResource>& imageResource);
@@ -112,6 +136,9 @@ private:
     VkSharedBaseObj<VideoStreamDemuxer> m_videoStreamDemuxer;
     VkSharedBaseObj<VulkanVideoFrameBuffer> m_vkVideoFrameBuffer;
     VkSharedBaseObj<VkVideoDecoder> m_vkVideoDecoder;
+#if (_TRANSCODING)
+    VkSharedBaseObj<VkVideoEncoder> m_vkVideoEncoder;
+#endif // _TRANSCODING
     VkSharedBaseObj<IVulkanVideoParser> m_vkParser;
     int64_t  m_currentBitstreamOffset;
     uint32_t m_videoFrameNum;

--- a/scripts/generate-dispatch-table.py
+++ b/scripts/generate-dispatch-table.py
@@ -363,6 +363,7 @@ vk_mvk_macos_surface = Extension(name='VK_MVK_macos_surface', version=1, guard='
 vk_khr_video_queue = Extension(name='VK_KHR_video_queue', version=1, guard='VK_USE_VIDEO_QUEUE', commands=[
     Command(name='GetPhysicalDeviceVideoFormatPropertiesKHR', dispatch='VkPhysicalDevice'),
     Command(name='GetPhysicalDeviceVideoCapabilitiesKHR', dispatch='VkPhysicalDevice'),
+    Command(name='GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR', dispatch='VkPhysicalDevice'),
     Command(name='CreateVideoSessionKHR', dispatch='VkDevice'),
     Command(name='DestroyVideoSessionKHR', dispatch='VkDevice'),
     Command(name='CreateVideoSessionParametersKHR', dispatch='VkDevice'),

--- a/vk_video_decoder/demos/CMakeLists.txt
+++ b/vk_video_decoder/demos/CMakeLists.txt
@@ -5,6 +5,10 @@ set(DEMO_INCLUDE_DIRS
     ${CMAKE_CURRENT_BINARY_DIR}/..
 )
 
+IF (${_TRANSCODING} MATCHES 1)
+    list (APPEND DEMO_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../vk_video_encoder/libs)
+ENDIF()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
     set(DisplayServer Win32)

--- a/vk_video_decoder/demos/vk-video-dec/CMakeLists.txt
+++ b/vk_video_decoder/demos/vk-video-dec/CMakeLists.txt
@@ -8,8 +8,19 @@ endmacro()
 generate_dispatch_table(${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/HelpersDispatchTable.h)
 generate_dispatch_table(${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/HelpersDispatchTable.cpp)
 
-set(sources
-    Main.cpp
+set(VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../vk_video_encoder/libs
+)
+
+if (${_TRANSCODING} MATCHES 1)
+    set(TARGET_EXECUTABLE_NAME vk-video-trans-test)
+    set(sources ${CMAKE_CURRENT_SOURCE_DIR}/../../../vk_video_transcoder/demos/vk-video-trans/Main.cpp)
+else()
+    set(TARGET_EXECUTABLE_NAME vk-video-dec-test)
+    set(sources Main.cpp)
+endif()
+
+list(APPEND sources
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkShell/Shell.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkShell/ShellDirect.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkShell/Shell.h
@@ -72,6 +83,46 @@ set(sources
     ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.h
     ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.cpp
     )
+
+IF (${_TRANSCODING} MATCHES 1)
+list(APPEND sources
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfigH264.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfigH264.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderDpbH264.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderDpbH264.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderH264.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderH264.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfigH265.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfigH265.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderDpbH265.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderDpbH265.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderH265.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderH265.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfigAV1.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfigAV1.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderDpbAV1.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderDpbAV1.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderAV1.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderAV1.h    
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfig.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoder.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoGopStructure.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoGopStructure.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoder.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/YCbCrConvUtilsCpu.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/YCbCrConvUtilsCpu.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoImagePool.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoImagePool.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanCommandBufferPool.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanCommandBufferPool.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanQueryPoolSet.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanQueryPoolSet.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoSessionParameters.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoSessionParameters.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoDisplayQueue.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoDisplayQueue.h)
+    add_compile_definitions(_TRANSCODING)
+ENDIF()
 
 set(definitions
     PRIVATE -DVK_NO_PROTOTYPES
@@ -143,10 +194,10 @@ list(APPEND includes PRIVATE ${VULKAN_VIDEO_APIS_INCLUDE})
 list(APPEND includes PRIVATE ${VULKAN_VIDEO_APIS_INCLUDE}/vulkan)
 list(APPEND includes PRIVATE ${VULKAN_VIDEO_APIS_INCLUDE}/nvidia_utils/vulkan)
 
-add_executable(vk-video-dec-test ${generate_helper_files} ${sources})
-target_compile_definitions(vk-video-dec-test ${definitions})
-target_include_directories(vk-video-dec-test ${includes})
-target_link_libraries(vk-video-dec-test ${libraries})
-add_dependencies(vk-video-dec-test generate_helper_files)
+add_executable(${TARGET_EXECUTABLE_NAME} ${generate_helper_files} ${sources})
+target_compile_definitions(${TARGET_EXECUTABLE_NAME} ${definitions})
+target_include_directories(${TARGET_EXECUTABLE_NAME} ${includes})
+target_link_libraries(${TARGET_EXECUTABLE_NAME} ${libraries})
+add_dependencies(${TARGET_EXECUTABLE_NAME} generate_helper_files)
 
-install(TARGETS vk-video-dec-test RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS ${TARGET_EXECUTABLE_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
+++ b/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
@@ -270,11 +270,13 @@ int32_t VkVideoDecoder::StartVideoSequence(VkParserDetectedVideoFormat* pVideoFo
     }
     m_numImageTypesEnabled |= DecodeFrameBufferIf::IMAGE_TYPE_MASK_DECODE_OUT;
 
+#if (!_TRANSCODING)
     if(!(videoCapabilities.flags & VK_VIDEO_CAPABILITY_SEPARATE_REFERENCE_IMAGES_BIT_KHR)) {
         // The implementation does not support individual images for DPB and so must use arrays
         m_useImageArray = VK_TRUE;
         m_useImageViewArray = VK_FALSE;
     }
+#endif //_TRANSCODING
 
     if (m_enableDecodeComputeFilter) {
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -66,6 +66,17 @@ void printHelp(VkVideoCodecOperationFlagBitsKHR codec)
     --deviceID                      <hexadec> : deviceID to be used, \n\
     --deviceUuid                    <string>  : deviceUuid to be used \n\
     --testOutOfOrderRecording      Testing only: enable testing for out-of-order-recording\n");
+#if (_TRANSCODING)
+    fprintf(stderr,
+    "--usageHints                   <integer> or <string> : Select encode usage hints \n\
+                                        default(0), transcoding(1), streaming(2), recording(3), conferencing(4) \n\
+    --contentHints                  <integer> or <string> : Select encode content hints \n\
+                                        default(0), camera(1), desktop(2), rendered(3) \n\
+    --preset                        <integer> : [1, 4] corresponds to p1..p4 \n\
+    --profile                       <integer> : 0 - low latency streaming, 1 - archiving, 2 - svc \n\
+    --bitrate                       <integer> : Target bitrate of the encoded file in Mbps (Megabit per second)\n\
+    --vbvbuf-ratio                  <integer> : [1, 4] multiplier to vbv buffer size: CBR's vbvbuf = bitrate/framerate * vbvbuf-ratio, VBR's vbvbuf = bitrate * vbvbuf-ratio \n");
+#endif //_TRANSCODING
 
     if ((codec == VK_VIDEO_CODEC_OPERATION_NONE_KHR) || (codec == VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR)) {
         fprintf(stderr, "\nH264 specific arguments: None\n");
@@ -306,9 +317,51 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
                 return -1;
             }
             gopStructure.SetGopFrameCount(gopFrameCount);
-            if (verbose) {
-                printf("Selected gopFrameCount: %d\n", gopFrameCount);
+            printf("Selected gopFrameCount: %d\n", gopFrameCount);
+#if (_TRANSCODING)
+        } else if (strcmp(argv[i], "--profile") == 0) {
+            if ((++i >= argc) !=1) {
+                int encodeProfileVal;
+                int sscanf_result = sscanf(argv[i], "%d", &encodeProfileVal);
+                if (sscanf_result != 1 || encodeProfileVal < 0 || encodeProfileVal > 2) {
+                    fprintf(stderr, "invalid parameter for %s\n", argv[i - 1]);
+                    return -1;
+                } else {
+                    encodingProfile = static_cast<EncoderConfig::ENCODING_PROFILE>(encodeProfileVal);
+                }
             }
+        } else if (strcmp(argv[i], "--preset") == 0) {
+            if ((++i >= argc) !=1) {
+                int pn;
+                int sscanf_result = sscanf(argv[i], "%d", &pn);
+                if (sscanf_result != 1 || pn < 1) {
+                    fprintf(stderr, "invalid parameter for %s\n", argv[i - 1]);
+                    return -1;
+                } else {
+                    qualityLevel = std::min(pn, 4) - 1;
+                }
+            }
+        } else if (strcmp(argv[i], "--bitrate") == 0) {
+            if ((++i >= argc) !=1) {
+            int targetBitrate;
+            int sscanf_result = sscanf(argv[i], "%d", &targetBitrate);
+            if (sscanf_result != 1 || targetBitrate <= 0 || targetBitrate >= 200) {
+                fprintf(stderr, "invalid parameter for %s\n", argv[i - 1]);
+                return -1;
+            }
+            averageBitrate = targetBitrate << 20;
+            }
+        } else if (strcmp(argv[i], "--vbvbuf-ratio") == 0) {
+            if ((++i >= argc) !=1) {
+                int vbvbuf_ratio;
+                int sscanf_result = sscanf(argv[i], "%d", &vbvbuf_ratio);
+                if (sscanf_result != 1 || vbvbuf_ratio <= 0 || vbvbuf_ratio > 8) {
+                    fprintf(stderr, "invalid parameter for %s\n", argv[i - 1]);
+                    return VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR;
+                }
+                vbvbufratio = vbvbuf_ratio;
+            }
+#endif //_TRANSCODING
         } else if (args[i] == "--idrPeriod") {
             int32_t idrPeriod = EncoderConfig::DEFAULT_GOP_IDR_PERIOD;
             if (++i >= argc || sscanf(args[i].c_str(), "%d", &idrPeriod) != 1) {
@@ -365,6 +418,46 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
                 fprintf(stderr, "invalid parameter for %s\n", args[i - 1].c_str());
                 return -1;
             }
+#if (_TRANSCODING)
+        } else if (args[i] == "--usageHints") {
+            if (++i >= argc) {
+                fprintf(stderr, "Invalid parameter for %s\n", args[i - 1].c_str());
+                return -1;
+            }
+            std::string encodeUsageStr = argv[i];
+            if (encodeUsageStr == "0" || encodeUsageStr == "default") {
+                encodeUsageHints = VK_VIDEO_ENCODE_USAGE_DEFAULT_KHR;
+            } else if (encodeUsageStr == "1" || encodeUsageStr == "transcoding") {
+                encodeUsageHints = VK_VIDEO_ENCODE_USAGE_TRANSCODING_BIT_KHR;
+            } else if (encodeUsageStr == "2" || encodeUsageStr == "streaming") {
+                encodeUsageHints = VK_VIDEO_ENCODE_USAGE_STREAMING_BIT_KHR;
+            } else if (encodeUsageStr == "3" || encodeUsageStr == "recording") {
+                encodeUsageHints = VK_VIDEO_ENCODE_USAGE_RECORDING_BIT_KHR;
+            } else if (encodeUsageStr == "4" || encodeUsageStr == "conferencing") {
+                encodeUsageHints = VK_VIDEO_ENCODE_USAGE_CONFERENCING_BIT_KHR;
+            } else {
+                fprintf(stderr, "Invalid encodeUsage: %s\n", encodeUsageStr.c_str());
+                return -1;
+            }
+        } else if (args[i] == "--contentHints") {
+            if (++i >= argc) {
+                fprintf(stderr, "Invalid parameter for %s\n", args[i - 1].c_str());
+                return -1;
+            }
+            std::string encodeContentStr = argv[i];
+            if (encodeContentStr == "0" || encodeContentStr == "default") {
+                encodeContentHints = VK_VIDEO_ENCODE_CONTENT_DEFAULT_KHR;
+            } else if (encodeContentStr == "1" || encodeContentStr == "camera") {
+                encodeContentHints = VK_VIDEO_ENCODE_CONTENT_CAMERA_BIT_KHR;
+            } else if (encodeContentStr == "2" || encodeContentStr == "desktop") {
+                encodeContentHints = VK_VIDEO_ENCODE_CONTENT_DESKTOP_BIT_KHR;
+            } else if (encodeContentStr == "3" || encodeContentStr == "rendered") {
+                encodeContentHints = VK_VIDEO_ENCODE_CONTENT_RENDERED_BIT_KHR;
+            } else {
+                fprintf(stderr, "Invalid encodeContent: %s\n", encodeContentStr.c_str());
+                return -1;
+            }
+#endif // _TRANSCODING
         } else if (args[i] == "--tuningMode") {
             if (++i >= argc) {
                 fprintf(stderr, "Invalid parameter for %s\n", args[i - 1].c_str());
@@ -485,6 +578,7 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
         return -1;
     }
 
+#if (!_TRANSCODING) // transcoding: the resolution will be read later when 1st frame is decoded
     if (input.width == 0) {
         fprintf(stderr, "The width was not specified\n");
         return -1;
@@ -494,6 +588,7 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
         fprintf(stderr, "The height was not specified\n");
         return -1;
     }
+#endif // !_TRANSCODING
 
     if (!outputFileHandler.HasFileName()) {
         const char* defaultOutName = (codec == VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR) ? "out.264" :
@@ -545,6 +640,7 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
         return -1;
     }
 
+#if (!_TRANSCODING)
     frameCount = inputFileHandler.GetFrameCount(input.width, input.height, input.bpp, input.chromaSubsampling);
 
     if (numFrames == 0 || numFrames > frameCount) {
@@ -557,6 +653,7 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
             return -1;
         }
     }
+#endif //!_TRANSCODING
 
     return DoParseArguments(argcount, arglist.data());
 }
@@ -601,8 +698,10 @@ VkResult EncoderConfig::CreateCodecConfig(int argc, char *argv[],
 
         VkResult result = vkEncoderConfigh264->InitializeParameters();
         if (result != VK_SUCCESS) {
+#if (!_TRANSCODING)
             assert(!"InitializeParameters failed");
             return result;
+#endif // !_TRANSCODING
         }
 
         encoderConfig = vkEncoderConfigh264;
@@ -619,8 +718,10 @@ VkResult EncoderConfig::CreateCodecConfig(int argc, char *argv[],
 
         VkResult result = vkEncoderConfigh265->InitializeParameters();
         if (result != VK_SUCCESS) {
+#if (!_TRANSCODING)
             assert(!"InitializeParameters failed");
             return result;
+#endif // !_TRANSCODING
         }
 
         encoderConfig = vkEncoderConfigh265;
@@ -637,8 +738,10 @@ VkResult EncoderConfig::CreateCodecConfig(int argc, char *argv[],
 
         VkResult result = vkEncoderConfigAV1->InitializeParameters();
         if (result != VK_SUCCESS) {
+#if (!_TRANSCODING)
             assert(!"InitializeParameters failed");
             return result;
+#endif //!_TRANSCODING
         }
 
         encoderConfig = vkEncoderConfigAV1;
@@ -664,12 +767,27 @@ void EncoderConfig::InitVideoProfile()
     }
 
     // update the video profile
+#if (_TRANSCODING)
+    VkVideoEncodeUsageInfoKHR encodeUsage {
+        .sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_USAGE_INFO_KHR,
+        .pNext = NULL,
+        .videoUsageHints = encodeUsageHints,
+        .videoContentHints = encodeContentHints,
+        .tuningMode = tuningMode,
+    };
+#endif // _TRANSCODING
+
     videoCoreProfile = VkVideoCoreProfile(codec, encodeChromaSubsampling,
                                           GetComponentBitDepthFlagBits(encodeBitDepthLuma),
                                           GetComponentBitDepthFlagBits(encodeBitDepthChroma),
                                           (videoProfileIdc != (uint32_t)-1) ? videoProfileIdc :
                                                   GetDefaultVideoProfileIdc(),
-                                          tuningMode);
+#if (_TRANSCODING)
+                                          encodeUsage
+#else
+                                          tuningMode
+#endif // _TRANSCODING
+                                        );
 }
 
 bool EncoderConfig::InitRateControl()

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -682,6 +682,10 @@ public:
     uint32_t codecBlockAlignment;
     uint32_t qualityLevel;
     VkVideoEncodeTuningModeKHR tuningMode;
+#if (_TRANSCODING)
+    VkVideoEncodeUsageFlagBitsKHR encodeUsageHints;
+    VkVideoEncodeContentFlagBitsKHR encodeContentHints;
+#endif // _TRANSCODING
     VkVideoCoreProfile videoCoreProfile;
     VkVideoCapabilitiesKHR videoCapabilities;
     VkVideoEncodeCapabilitiesKHR videoEncodeCapabilities;
@@ -748,6 +752,12 @@ public:
     uint32_t enablePreprocessComputeFilter : 1;
     uint32_t enableOutOfOrderRecording : 1; // Testing only - don't use for production!
 
+#if (_TRANSCODING)
+    int vbvbufratio;
+    enum ENCODING_PROFILE { LOW_LATENCY_STREAMING = 0, ARCHIVING, SVC, ENUM_MAXVAL_NOTSET };
+    ENCODING_PROFILE encodingProfile;
+#endif // _TRANSCODING
+
     EncoderConfig()
     : refCount(0)
     , appName()
@@ -773,6 +783,10 @@ public:
     , numFrames(0)
     , codecBlockAlignment(16)
     , qualityLevel(0)
+#if (_TRANSCODING)
+    , encodeUsageHints(VK_VIDEO_ENCODE_USAGE_DEFAULT_KHR)
+    , encodeContentHints(VK_VIDEO_ENCODE_CONTENT_DEFAULT_KHR)
+#endif // _TRANSCODING
     , tuningMode(VK_VIDEO_ENCODE_TUNING_MODE_DEFAULT_KHR)
     , videoCoreProfile(codec, encodeChromaSubsampling, encodeBitDepthLuma, encodeBitDepthChroma)
     , videoCapabilities()
@@ -833,6 +847,10 @@ public:
     , selectVideoWithComputeQueue(false)
     , enablePreprocessComputeFilter(false)
     , enableOutOfOrderRecording(false)
+#if (_TRANSCODING)
+    , vbvbufratio(1)
+    , encodingProfile(ENUM_MAXVAL_NOTSET)
+#endif // _TRANSCODING
     { }
 
     virtual ~EncoderConfig() {}

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -380,7 +380,15 @@ VkResult EncoderConfigH264::InitDeviceCapabilities(const VulkanDeviceContext* vk
 
 int8_t EncoderConfigH264::InitDpbCount()
 {
+#if (!_TRANSCODING)
     dpbCount = (gopStructure.GetConsecutiveBFrameCount() > 0) ? gopStructure.GetConsecutiveBFrameCount() : 1;
+#else
+    dpbCount = gopStructure.GetConsecutiveBFrameCount();
+    if (dpbCount == 0) {
+        dpbCount = 1;
+        return dpbCount + 1;
+    }
+#endif // !_TRANSCODING
     // spsInfo->level represents the smallest level that we require for the
     // given stream. This level constrains the maximum size (in terms of
     // number of frames) that the DPB can have. levelDpbSize is this maximum
@@ -458,6 +466,16 @@ bool EncoderConfigH264::InitRateControl()
     }
 
     // Use the level limit for the max VBV buffer size, and no more than 8 seconds at peak rate
+#if (_TRANSCODING)
+    if (encodingProfile == EncoderConfig::LOW_LATENCY_STREAMING)
+    {
+        vbvBufferSize = (uint32_t)(averageBitrate / frameRate * vbvbufratio); // averageBitrate is a uint32_t, no overflow
+    }
+    else if (encodingProfile == EncoderConfig::ARCHIVING)
+    {
+        vbvBufferSize = averageBitrate * vbvbufratio;
+    } else // Tymur: temporarily disable the following feature if encodingProfile is specified (the above code will be used instead)
+#endif // _TRANSCODING
     if (vbvBufferSize == 0) {
         vbvBufferSize = std::min(levelLimits[levelIdc].maxCPB * 1000, 120000000U);
         if (rateControlMode != VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR)

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.cpp
@@ -16,7 +16,7 @@
 
 #include "VkVideoGopStructure.h"
 
-VkVideoGopStructure::VkVideoGopStructure(uint8_t gopFrameCount,
+VkVideoGopStructure::VkVideoGopStructure(uint16_t gopFrameCount,
                                          int32_t idrPeriod,
                                          uint8_t consecutiveBFrameCount,
                                          uint8_t temporalLayerCount,
@@ -38,7 +38,7 @@ VkVideoGopStructure::VkVideoGopStructure(uint8_t gopFrameCount,
 bool VkVideoGopStructure::Init(uint64_t maxNumFrames)
 {
     m_gopFrameCycle = (uint8_t)(m_consecutiveBFrameCount + 1);
-    m_gopFrameCount = (uint8_t)std::min<uint64_t>(m_gopFrameCount, maxNumFrames);
+    m_gopFrameCount = (uint16_t)std::min<uint64_t>(m_gopFrameCount, maxNumFrames);
     if (m_idrPeriod > 0) {
         m_idrPeriod = (uint32_t)std::min<uint64_t>(m_idrPeriod, maxNumFrames);
     }

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.h
@@ -26,7 +26,7 @@
 #include <iostream>
 #include <iomanip>
 
-static const uint32_t MAX_GOP_SIZE = 64;
+static const uint32_t MAX_GOP_SIZE = UINT16_MAX;
 
 class VkVideoGopStructure {
 
@@ -54,7 +54,7 @@ public:
     struct GopPosition {
         uint32_t   inputOrder;  // input order in the IDR sequence
         uint32_t   encodeOrder; // encode order in the Gop
-        uint8_t    inGop;       // The position in Gop in input order
+        uint16_t   inGop;       // The position in Gop in input order
         int8_t     numBFrames;  // Number of B frames in this part of the Gop, -1 if not a B frame
         int8_t     bFramePos;   // The B position in Gop, -1 if not a B frame
         FrameType  pictureType;   // The type of the picture
@@ -71,7 +71,7 @@ public:
         {}
     };
 
-    VkVideoGopStructure(uint8_t gopFrameCount = 8,
+    VkVideoGopStructure(uint16_t gopFrameCount = 8,
                         int32_t idrPeriod = 60,
                         uint8_t consecutiveBFrameCount = 2,
                         uint8_t temporalLayerCount = 1,
@@ -106,8 +106,8 @@ public:
     // If it is set to 0, the rate control algorithm may assume an
     // implementation-dependent GOP length. If it is set to UINT32_MAX,
     // the GOP length is treated as infinite.
-    void SetGopFrameCount(uint8_t gopFrameCount) { m_gopFrameCount = gopFrameCount; }
-    uint8_t GetGopFrameCount() const { return m_gopFrameCount; }
+    void SetGopFrameCount(uint16_t gopFrameCount) { m_gopFrameCount = gopFrameCount; }
+    uint16_t GetGopFrameCount() const { return m_gopFrameCount; }
 
     // idrPeriod is the interval, in terms of number of frames, between two IDR frames (see IDR period).
     // If it is set to 0, the rate control algorithm may assume an implementation-dependent IDR period.
@@ -173,7 +173,7 @@ public:
 
         // consecutiveBFrameCount can be modified before the IDR sequence
         uint8_t consecutiveBFrameCount = m_consecutiveBFrameCount;
-        gopPos.inGop = (uint8_t)(gopState.positionInInputOrder % m_gopFrameCount);
+        gopPos.inGop = (uint16_t)(gopState.positionInInputOrder % m_gopFrameCount);
 
         if (gopPos.inGop == 0) {
             // This is the start of a new (open or close) GOP.
@@ -269,7 +269,7 @@ public:
     }
 
 private:
-    uint8_t               m_gopFrameCount;
+    uint16_t              m_gopFrameCount;
     uint8_t               m_consecutiveBFrameCount;
     uint8_t               m_gopFrameCycle;
     uint8_t               m_temporalLayerCount;

--- a/vk_video_transcoder/BUILD.md
+++ b/vk_video_transcoder/BUILD.md
@@ -1,0 +1,216 @@
+# Build Instructions
+
+Instructions for building this repository on Linux, Windows, L4.
+
+## Index
+
+1. [Repository Set-Up](#repository-set-up)
+2. [Windows Build](#building-on-windows)
+3. [Linux Build](#building-on-linux)
+4. [Linux for Tegra Build](#building-on-linux-for-tegra)
+5. [Android Build](#building-on-android)
+
+## Contributing to the Repository
+
+If you intend to contribute, the preferred work flow is for you to develop
+your contribution in a fork of this repository in your GitHub account and
+then submit a pull request.
+Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file in this repository for more details.
+
+## Repository Set-Up
+
+  Please make sure you have installed the latest NVIDIA BETA drivers from https://developer.nvidia.com/vulkan-driver.
+  The minimum supported BETA driver versions by this application are 527.86 (Windows) / 525.47.04 (Linux) that
+  must support Vulkan API version 1.3.230 or later.
+  The Windows and Linux BETA drivers are available for download at https://developer.nvidia.com/vulkan-beta-51769-windows
+  and https://developer.nvidia.com/vulkan-beta-5154924-linux, respectively.
+
+### Download the Repository
+
+   Vulkan Video Test application Gerrit repository:
+   VULKAN_VIDEO_GIT_REPO="https://github.com/nvpro-samples/vk_video_samples.git"
+
+   $ git clone $VULKAN_VIDEO_GIT_REPO
+
+   APP_INSTALLED_LOC=$(pwd)/"vk_video_samples/vk_video_transcoder"
+
+## Building On Windows
+
+### Windows Build Requirements
+
+Windows 10 or Windows 11 with the following software packages:
+
+- Microsoft Visual Studio VS2017 or later (any version).
+- [CMake](http://www.cmake.org/download/)
+  - Tell the installer to "Add CMake to the system PATH" environment variable.
+- [Python 3](https://www.python.org/downloads)
+  - Select to install the optional sub-package to add Python to the system PATH
+    environment variable.
+  - Ensure the `pip` module is installed (it should be by default)
+  - Python3.3 or later is necessary for the Windows py.exe launcher that is used to select python3
+  rather than python2 if both are installed
+- [Git](http://git-scm.com/download/win)
+  - Tell the installer to allow it to be used for "Developer Prompt" as well as "Git Bash".
+  - Tell the installer to treat line endings "as is" (i.e. both DOS and Unix-style line endings).
+  - Install both the 32-bit and 64-bit versions, as the 64-bit installer does not install the
+    32-bit libraries and tools.
+- [Vulkan SDK](https://vulkan.lunarg.com)
+  - install current Vulkan SDK (i.e. VulkanSDK-1.3.*-Installer.exe) from https://vulkan.lunarg.com/
+- [FFMPEG libraries for Windows]
+    Download the latest version of the FFMPEG shared libraries archive from https://github.com/BtbN/FFmpeg-Builds/releases.
+    The archive must have the following pattern in the name ffmpeg-*-win64-*-shared.zip
+    For example:
+    https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl-shared.zip
+    Then extract the archive to <APP_INSTALLED_LOC>\bin\libs\ffmpeg and add the path of the <APP_INSTALLED_LOC>\bin\libs\ffmpeg\win64\ of
+    the application. Please make sure that <APP_INSTALLED_LOC>\bin\libs\ffmpeg\win64\bin location contains
+    avformat-59.dll, avutil-59.dll and avcodec-59.dll shared libraries and <APP_INSTALLED_LOC>\bin\libs\ffmpeg\win64\lib contains the
+    corresponding lib files.
+- Notes for using [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
+  - Vulkan Video currently does not support [Windows Subsystem for Linux].
+
+### Windows Build - Microsoft Visual Studio
+
+1. Open a Developer Command Prompt for VS201x
+2. Change directory to `<APP_INSTALLED_LOC>/../vk_video_decoder` -- the decoder folder in the cloned git repository
+3. Run `update_external_sources.bat` -- this will download and build external components
+4. Change directory to `<APP_INSTALLED_LOC>` -- the vk_video_transcoder folder in the cloned git repository
+5. Create a `build` directory, change into that directory, and run cmake and build as follows:
+
+### Windows Build for debug - using shell
+
+        cmake .. -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_INSTALL_PREFIX="$(pwd)/install/Debug" -DCMAKE_BUILD_TYPE=Debug
+        cmake --build . --parallel 16 --config Debug
+        cmake --build . --config Debug --target INSTALL
+
+### Windows Build for release - using shell
+
+        cmake .. -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_INSTALL_PREFIX="$(pwd)/install/Release" -DCMAKE_BUILD_TYPE=Release
+        cmake --build . --parallel 16 --config Release
+        cmake --build . --config Release --target INSTALL
+
+### Windows Notes
+
+#### The Vulkan Loader Library
+
+Vulkan programs must be able to find and use the vulkan-1.dll library.
+While several of the test and demo projects in the Windows solution set this up automatically, doing so manually may be necessary for custom projects or solutions.
+Make sure the library is either installed in the C:\Windows\System folder, or that the PATH environment variable includes the folder where the library resides.
+
+## Building On Linux
+
+### Linux Build Requirements
+
+This repository has been built and tested on the two most recent Ubuntu LTS versions with
+Vulkan SDK vulkansdk-linux-x86_64-1.2.189.0.tar.gz from https://vulkan.lunarg.com/sdk/home#linux.
+Currently, the oldest supported version is Ubuntu 18.04.5 LTS, meaning that the minimum supported
+compiler versions are GCC 7.5.0 and Clang 6.0.0, although earlier versions may work.
+It should be straightforward to adapt this repository to other Linux distributions.
+
+**Required Package List:**
+
+1. sudo apt-get install git cmake build-essential libx11-xcb-dev libxkbcommon-dev libmirclient-dev libwayland-dev libxrandr-dev libavcodec-dev libavformat-dev libavutil-dev ninja-build
+
+### Linux Vulkan Video Transcoder Demo Build
+
+2. In a Linux terminal, `cd <APP_INSTALLED_LOC>/vk_video_decoder` -- the root of the cloned git repository
+        cd $APP_INSTALLED_LOC
+3. Execute `./update_external_sources.sh` -- this will download and build external components
+        $ ./update_external_sources.sh
+4. Create a `build` directory, change into that directory:
+
+        mkdir build
+        cd build
+
+5. Run cmake to configure the build:
+
+        `cd <APP_INSTALLED_LOC>/vk_video_transcoder`
+
+        # Transcoder build configuration (please select Debug or Release build type):
+        For example, for Debug build:
+        cmake -DCMAKE_BUILD_TYPE=Debug ..
+
+        OR for Debug build:
+        cmake -DCMAKE_BUILD_TYPE=Release ..
+
+6. Run `make -j16` to build the sample application.
+
+7. Usage example:
+
+        `./demos/vk-video-dec-test -i inputfile.mkv --codec hevc --profile 0 --bitrate 5 --preset 1 --vbvbuf-ratio 2`
+        * `profile 0` - only p-frames, `profile 1` - 3 b-frames, `bitrate` is a target bitrate in MB/s, please see `--help` for more information
+
+### WSI Support Build Options
+
+By default, the Vulkan video demo is built with support for all 3 Vulkan-defined WSI display servers: Xcb, Xlib and Wayland, as well as direct-to-display.
+It is recommended to build the repository components with support for these display servers to maximize their usability across Linux platforms.
+If it is necessary to build these modules without support for one of the display servers, the appropriate CMake option of the form `BUILD_WSI_xxx_SUPPORT` can be set to `OFF`.
+See the top-level CMakeLists.txt file for more info.
+
+### Linux Decoder Tests
+
+Before you begin, check if your driver has Vulkan Video extensions enabled:
+
+        $ vulkaninfo | grep VK_KHR_video
+
+The output should be:
+           VK_KHR_video_decode_queue : extension revision 1
+           VK_KHR_video_encode_queue : extension revision 1
+           VK_KHR_video_queue : extension revision 1
+
+To run the Vulkan Video Decode sample from the build dir (for Windows change to build\install\Debug\bin\ or build\install\Release\bin\):
+
+        $ ./demos/vk-video-dec-test -i '<Video content file with h.264 or h.265 format>'
+        # -- Optional parameter is the max number of frames to be displayed with --c N.
+        # For example if the max frames required are 100, then:
+        $ ./demos/vk-video-dec-test -i /data/nvidia-l4t/video-samples/Palm_Trees_4Videvo.mov --c 100
+        # One can find some sample videos in h.264 and h.265 formats here:
+        # http://jell.yfish.us/
+
+You can select which WSI subsystem is used to build the demos using a CMake option
+called DEMOS_WSI_SELECTION.
+Supported options are XCB (default), XLIB, WAYLAND, and MIR.
+Note that you must build using the corresponding BUILD_WSI_*_SUPPORT enabled at the
+base repository level (all SUPPORT options are ON by default).
+For instance, creating a build that will use Xlib to build the demos,
+your CMake command line might look like:
+
+    cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DDEMOS_WSI_SELECTION=XLIB
+
+## Building On Linux for Tegra
+
+### Linux for Tegra Build Requirements
+
+This repository has been built and tested on the two most recent Ubuntu LTS versions.
+Currently, the oldest supported version is Ubuntu 18.04.5 LTS, meaning that the minimum supported compiler versions are GCC 7.5.0 and Clang 6.0.0, although earlier versions may work.
+It should be straightforward to adapt this repository to other Linux distributions.
+
+**Required Package List:**
+
+    sudo apt-get install git cmake build-essential libx11-xcb-dev libxkbcommon-dev libmirclient-dev libwayland-dev libxrandr-dev libavcodec-dev libavformat-dev libavutil-dev
+
+### Linux for Tegra Vulkan Video Demo Build
+
+1. Set the TEGRA_TOP environment variables to the location of the application
+        export TEGRA_TOP=$APP_INSTALLED_LOC
+
+2. Follow the Linux Build instructions above
+
+## Ninja Builds - All Platforms
+
+The [Qt Creator IDE](https://qt.io/download-open-source/#section-2) can open a root CMakeList.txt
+as a project directly, and it provides tools within Creator to configure and generate Vulkan SDK
+build files for one to many targets concurrently.
+Alternatively, when invoking CMake, use the `-G "Codeblocks - Ninja"` option to generate Ninja build
+files to be used as project files for QtCreator
+
+- Follow the steps defined elsewhere for the OS using the update\_external\_sources script or as
+  shown in **Loader and Validation Layer Dependencies** below
+- Open, configure, and build the glslang CMakeList.txt files. Note that building the glslang
+  project will provide access to spirv-tools and spirv-headers
+- Then do the same with the Vulkan-LoaderAndValidationLayers CMakeList.txt file
+- In order to debug with QtCreator, a
+  [Microsoft WDK: eg WDK 10](http://go.microsoft.com/fwlink/p/?LinkId=526733) is required.
+
+Note that installing the WDK breaks the MSVC vcvarsall.bat build scripts provided by MSVC,
+requiring that the LIB, INCLUDE, and PATHenv variables be set to the WDK paths by some other means
+

--- a/vk_video_transcoder/CMakeLists.txt
+++ b/vk_video_transcoder/CMakeLists.txt
@@ -1,0 +1,2 @@
+set (_TRANSCODING 1)
+add_subdirectory("../vk_video_decoder" ${CMAKE_CURRENT_BINARY_DIR})

--- a/vk_video_transcoder/demos/vk-video-trans/Main.cpp
+++ b/vk_video_transcoder/demos/vk-video-trans/Main.cpp
@@ -1,0 +1,329 @@
+/*
+ * Copyright (C) 2016 Google, Inc.
+ * Copyright 2020 NVIDIA Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <string>
+#include <vector>
+#include <cstring>
+#include <cstdio>
+
+#include "VkCodecUtils/VulkanDeviceContext.h"
+#include "VkCodecUtils/ProgramConfig.h"
+#include "VkCodecUtils/VulkanVideoProcessor.h"
+#include "VkCodecUtils/VulkanDecoderFrameProcessor.h"
+#include "VkShell/Shell.h"
+
+#if (_TRANSCODING)
+#include "VkVideoEncoder/VkVideoEncoder.h"
+#include "VkVideoEncoder/VkEncoderConfig.h"
+#include "VkCodecUtils/VulkanVideoDisplayQueue.h"
+#include "VkCodecUtils/VulkanVideoEncodeDisplayQueue.h"
+#include "VkCodecUtils/VulkanEncoderFrameProcessor.h"
+#endif
+
+int main(int argc, const char **argv) {
+
+    ProgramConfig programConfig(argv[0]);
+    programConfig.ParseArgs(argc, argv);
+
+    // In the regular application usecase the CRC output variables are allocated here and also output as part of main.
+    // In the library case it is up to the caller of the library to allocate the values and initialize them.
+    std::vector<uint32_t> crcAllocation;
+    crcAllocation.resize(programConfig.crcInitValue.size());
+    if (crcAllocation.empty() == false) {
+        programConfig.crcOutput = &crcAllocation[0];
+        for (size_t i = 0; i < programConfig.crcInitValue.size(); i += 1) {
+            crcAllocation[i] = programConfig.crcInitValue[i];
+        }
+    }
+
+    static const char* const requiredInstanceLayers[] = {
+        "VK_LAYER_KHRONOS_validation",
+        nullptr
+    };
+
+#if _TRANSCODING
+    programConfig.enableVideoEncoder = 1;
+    programConfig.noPresent = 1;
+    VkSharedBaseObj<EncoderConfig> encoderConfig;
+    if (VK_SUCCESS != EncoderConfig::CreateCodecConfig(argc, (char**)argv, encoderConfig)) {
+        return -1;
+    }    
+    const int32_t numEncodeQueues = 1;  // only one HW encoder instance
+#endif //_TRANSCODING
+
+    static const char* const requiredInstanceExtensions[] = {
+        VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
+        nullptr
+    };
+
+    static const char* const requiredWsiInstanceExtensions[] = {
+        // Required generic WSI extensions
+        VK_KHR_SURFACE_EXTENSION_NAME,
+        nullptr
+    };
+
+    static const char* const requiredDeviceExtension[] = {
+#if defined(__linux) || defined(__linux__) || defined(linux)
+        VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+        VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME,
+#endif
+        VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME,
+        VK_KHR_VIDEO_QUEUE_EXTENSION_NAME,
+        VK_KHR_VIDEO_DECODE_QUEUE_EXTENSION_NAME,
+#if _TRANSCODING
+        VK_KHR_VIDEO_ENCODE_QUEUE_EXTENSION_NAME,
+        VK_KHR_VIDEO_MAINTENANCE_1_EXTENSION_NAME,
+#endif
+        nullptr
+    };
+
+    static const char* const requiredWsiDeviceExtension[] = {
+        // Add the WSI required device extensions
+        VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+#if !defined(VK_USE_PLATFORM_WIN32_KHR)
+        // VK_EXT_DISPLAY_CONTROL_EXTENSION_NAME,
+#endif
+        nullptr
+    };
+
+    static const char* const optinalDeviceExtension[] = {
+        VK_EXT_YCBCR_2PLANE_444_FORMATS_EXTENSION_NAME,
+        VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME,
+        VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
+        VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME,
+        nullptr
+    };
+
+    VulkanDeviceContext vkDevCtxt;
+
+    if (programConfig.validate) {
+        vkDevCtxt.AddReqInstanceLayers(requiredInstanceLayers);
+        vkDevCtxt.AddReqInstanceExtensions(requiredInstanceExtensions);
+    }
+
+    // Add the Vulkan video required device extensions
+    vkDevCtxt.AddReqDeviceExtensions(requiredDeviceExtension);
+    vkDevCtxt.AddOptDeviceExtensions(optinalDeviceExtension);
+
+    /********** Start WSI instance extensions support *******************************************/
+    if (!programConfig.noPresent) {
+        const std::vector<VkExtensionProperties>& wsiRequiredInstanceInstanceExtensions =
+                Shell::GetRequiredInstanceExtensions(programConfig.directMode);
+
+        for (size_t e = 0; e < wsiRequiredInstanceInstanceExtensions.size(); e++) {
+            vkDevCtxt.AddReqInstanceExtension(wsiRequiredInstanceInstanceExtensions[e].extensionName);
+        }
+
+        // Add the WSI required instance extensions
+        vkDevCtxt.AddReqInstanceExtensions(requiredWsiInstanceExtensions);
+
+        // Add the WSI required device extensions
+        vkDevCtxt.AddReqDeviceExtensions(requiredWsiDeviceExtension);
+    }
+    /********** End WSI instance extensions support *******************************************/
+
+    VkResult result = vkDevCtxt.InitVulkanDevice(programConfig.appName.c_str(),
+                                                 programConfig.verbose);
+    if (result != VK_SUCCESS) {
+        printf("Could not initialize the Vulkan device!\n");
+        return -1;
+    }
+
+    result = vkDevCtxt.InitDebugReport(programConfig.validate,
+                                       programConfig.validateVerbose);
+    if (result != VK_SUCCESS) {
+        return -1;
+    }
+
+    const bool supportsDisplay = true;
+    const int32_t numDecodeQueues = ((programConfig.queueId != 0) ||
+                                     (programConfig.enableHwLoadBalancing != 0)) ?
+                                     -1 : // all available HW decoders
+                                      1;  // only one HW decoder instance
+
+    VkQueueFlags requestVideoDecodeQueueMask = VK_QUEUE_VIDEO_DECODE_BIT_KHR;
+
+    VkQueueFlags requestVideoEncodeQueueMask = 0;
+    if (programConfig.enableVideoEncoder) {
+        requestVideoEncodeQueueMask |= VK_QUEUE_VIDEO_ENCODE_BIT_KHR;
+    }
+
+    if (programConfig.selectVideoWithComputeQueue) {
+        requestVideoDecodeQueueMask |= VK_QUEUE_COMPUTE_BIT;
+        if (programConfig.enableVideoEncoder) {
+            requestVideoEncodeQueueMask |= VK_QUEUE_COMPUTE_BIT;
+        }
+    }
+
+    VkQueueFlags requestVideoComputeQueueMask = 0;
+    if (programConfig.enablePostProcessFilter != -1) {
+        requestVideoComputeQueueMask = VK_QUEUE_COMPUTE_BIT;
+    }
+
+    VkSharedBaseObj<VulkanVideoProcessor> vulkanVideoProcessor;
+    result = VulkanVideoProcessor::Create(programConfig, &vkDevCtxt, vulkanVideoProcessor);
+    if (result != VK_SUCCESS) {
+        return -1;
+    }
+
+    VkSharedBaseObj<VkVideoQueue<VulkanDecodedFrame>> videoQueue(vulkanVideoProcessor);
+    VkSharedBaseObj<FrameProcessor> frameProcessor;
+    result = CreateDecoderFrameProcessor(&vkDevCtxt, videoQueue, frameProcessor);
+    if (result != VK_SUCCESS) {
+        return -1;
+    }
+
+    VkVideoCodecOperationFlagsKHR videoDecodeCodecs = (VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR  |
+                                                       VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR  |
+                                                       VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR);
+
+    VkVideoCodecOperationFlagsKHR videoEncodeCodecs = ( VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR  |
+                                                        VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR  |
+                                                        VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR);
+
+    VkVideoCodecOperationFlagsKHR videoCodecs = videoDecodeCodecs |
+                                        (programConfig.enableVideoEncoder ? videoEncodeCodecs : VK_VIDEO_CODEC_OPERATION_NONE_KHR);
+
+
+    if (supportsDisplay && !programConfig.noPresent) {
+
+        const Shell::Configuration configuration(programConfig.appName.c_str(),
+                                                 programConfig.backBufferCount,
+                                                 programConfig.directMode);
+        VkSharedBaseObj<Shell> displayShell;
+        result = Shell::Create(&vkDevCtxt, configuration, frameProcessor, displayShell);
+        if (result != VK_SUCCESS) {
+            assert(!"Can't allocate display shell! Out of memory!");
+            return -1;
+        }
+
+        result = vkDevCtxt.InitPhysicalDevice(programConfig.deviceId, programConfig.GetDeviceUUID(),
+                                              (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_TRANSFER_BIT |
+                                              requestVideoComputeQueueMask |
+                                              requestVideoDecodeQueueMask |
+                                              requestVideoEncodeQueueMask),
+                                              displayShell,
+                                              requestVideoDecodeQueueMask,
+                                              (VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR |
+                                               VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR |
+                                               VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR),
+                                              requestVideoEncodeQueueMask,
+                                              (VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR |
+                                               VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR |
+                                               VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR));
+        if (result != VK_SUCCESS) {
+
+            assert(!"Can't initialize the Vulkan physical device!");
+            return -1;
+        }
+        assert(displayShell->PhysDeviceCanPresent(vkDevCtxt.getPhysicalDevice(),
+                                                   vkDevCtxt.GetPresentQueueFamilyIdx()));
+
+        vkDevCtxt.CreateVulkanDevice(numDecodeQueues,
+                                     programConfig.enableVideoEncoder ? 1 : 0, // num encode queues
+                                     videoCodecs,
+                                     false, //  createTransferQueue
+                                     true,  // createGraphicsQueue
+                                     true,  // createDisplayQueue
+                                     requestVideoComputeQueueMask != 0  // createComputeQueue
+                                     );
+        vulkanVideoProcessor->Initialize(&vkDevCtxt, programConfig);
+
+
+        displayShell->RunLoop();
+
+    } else {
+
+        result = vkDevCtxt.InitPhysicalDevice(programConfig.deviceId, programConfig.GetDeviceUUID(),
+                                              (VK_QUEUE_TRANSFER_BIT | requestVideoDecodeQueueMask  |
+                                              requestVideoComputeQueueMask |
+                                              requestVideoEncodeQueueMask),
+                                              nullptr,
+                                              requestVideoDecodeQueueMask);
+        if (result != VK_SUCCESS) {
+
+            assert(!"Can't initialize the Vulkan physical device!");
+            return -1;
+        }
+
+
+        result = vkDevCtxt.CreateVulkanDevice(numDecodeQueues,
+#ifdef _TRANSCODING
+                                              numEncodeQueues,
+#else
+                                              0,     // num encode queues
+#endif //_TRANSCODING
+                                              videoCodecs,
+                                              // If no graphics or compute queue is requested, only video queues
+                                              // will be created. Not all implementations support transfer on video queues,
+                                              // so request a separate transfer queue for such implementations.
+                                              ((vkDevCtxt.GetVideoDecodeQueueFlag() & VK_QUEUE_TRANSFER_BIT) == 0), //  createTransferQueue
+                                              false, // createGraphicsQueue
+                                              false, // createDisplayQueue
+                                              requestVideoComputeQueueMask != 0   // createComputeQueue
+                                              );
+        if (result != VK_SUCCESS) {
+
+            assert(!"Failed to create Vulkan device!");
+            return -1;
+        }
+
+        vulkanVideoProcessor->Initialize(&vkDevCtxt, programConfig);
+
+        const int numberOfFrames = programConfig.decoderQueueSize;
+        int ret = frameProcessor->CreateFrameData(numberOfFrames);
+        assert(ret == numberOfFrames);
+        if (ret != numberOfFrames) {
+            return -1;
+        }
+#if (_TRANSCODING)
+    int curFrameIndex = 0;
+#endif // _TRANSCODING
+        bool continueLoop = true;
+        do {
+#if (_TRANSCODING)
+            continueLoop = frameProcessor->OnFrameTranscoding(0, &programConfig, encoderConfig);
+            curFrameIndex++;
+#else
+            continueLoop = frameProcessor->OnFrame(0);
+#endif //_TRANSCODING
+        } while (continueLoop);
+#if (_TRANSCODING)
+        vulkanVideoProcessor->getEncoder()->WaitForThreadsToComplete();
+        std::cout << "Done processing " << curFrameIndex << " input frames!" << std::endl
+                << "Encoded file's location is at " << encoderConfig->outputFileHandler.GetFileName()
+                << std::endl;
+#endif // _TRANSCODING
+        frameProcessor->DestroyFrameData();
+    }
+
+    if (programConfig.outputcrc != 0) {
+        fprintf(programConfig.crcOutputFile, "CRC: ");
+        for (size_t i = 0; i < programConfig.crcInitValue.size(); i += 1) {
+            fprintf(programConfig.crcOutputFile, "0x%08X ", crcAllocation[i]);
+        }
+
+        fprintf(programConfig.crcOutputFile, "\n");
+        if (programConfig.crcOutputFile != stdout) {
+            fclose(programConfig.crcOutputFile);
+            programConfig.crcOutputFile = stdout;
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
A brief explanation: transcoding is an extension of the decoder - it is based on both the decoder and the encoder. Initially, only transcoding from one codec to another is supported (you can specify a target bitrate, a vbv buffer relative size, vbr or cbr as well). But from maintenance and support points of view it would be time consuming to track and update everything from the decoder and the encoder (however the transcoder has it's separate own project folder and Main), thus it is better to put the transcoder specific changes together with the decoder's and the encoder's code. Moreover keeping the transcoding completely separate code would lead to the huge code duplication (even If we are speaking about a separate CMake project - it would duplicate approximately 80-90% of the decoder's project CMake files, moreover it would be required to modify CMake files copied from the decoder and again it would be difficult to maintain the separate CMake project since it will be based on the decoder's CMake project - that's why It would be better to set(_TRANCODING, 1) and pass it using add_subdirectory). You can build the transcoder from it's own folder using CMake in the same way as for the decoder or the encoder (see Build.md in the transcoder's folder). My goal was to minimize the code duplication and efforts for the code maintenance and support.