### PR TITLE
Fixed potential rare corner cases

### DIFF
--- a/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeAVX2.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeAVX2.cpp
@@ -49,6 +49,10 @@ size_t VulkanVideoDecoder::next_start_code<SIMD_ISA::AVX2>(const uint8_t *pdatai
             }
         } // main processing loop end
         m_BitBfr = (pdatain[i-2] << 8) | pdatain[i-1];
+        if (i >= datasize) {
+            found_start_code = false;
+            return datasize;
+        }
     }
     // process a tail (rest):
     uint32_t bfr = m_BitBfr;

--- a/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeAVX512.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeAVX512.cpp
@@ -53,6 +53,10 @@ size_t VulkanVideoDecoder::next_start_code<SIMD_ISA::AVX512>(const uint8_t *pdat
             }
         } // main processing loop end
         m_BitBfr = (pdatain[i-2] << 8) | pdatain[i-1];
+        if (i >= datasize) {
+            found_start_code = false;
+            return datasize;
+        }
     }
     // process a tail (rest):
     uint32_t bfr = m_BitBfr;

--- a/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeNEON.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeNEON.cpp
@@ -62,6 +62,10 @@ size_t VulkanVideoDecoder::next_start_code<SIMD_ISA::NEON>(const uint8_t *pdatai
             }
         } // main processing loop end
         m_BitBfr = (pdatain[i-2] << 8) | pdatain[i-1];
+        if (i >= datasize) {
+            found_start_code = false;
+            return datasize;
+        }
     }
     // process a tail (rest):
     uint32_t bfr = m_BitBfr;

--- a/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeSSSE3.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeSSSE3.cpp
@@ -47,6 +47,10 @@ size_t VulkanVideoDecoder::next_start_code<SIMD_ISA::SSSE3>(const uint8_t *pdata
             }
         } // main processing loop end
         m_BitBfr = (pdatain[i-2] << 8) | pdatain[i-1];
+        if (i >= datasize) {
+            found_start_code = false;
+            return datasize;
+        }
     }
     // process a tail (rest):
     uint32_t bfr = m_BitBfr;

--- a/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeSVE.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeSVE.cpp
@@ -65,8 +65,12 @@ size_t VulkanVideoDecoder::next_start_code<SIMD_ISA::SVE>(const uint8_t *pdatain
             // hotspot end
         }
     }
-    m_BitBfr = (pdatain[datasize-2] << 8) | pdatain[datasize-1];
-    found_start_code = ((m_BitBfr & 0x00ffffff) == 1);
+    // a very rare case:
+    if (datasize >= 2) {
+        m_BitBfr = pdatain[datasize-2];
+    }
+    m_BitBfr = (m_BitBfr << 8) | pdatain[datasize >= 1 ? datasize - 1 : 0];
+    found_start_code = false;
     return datasize;
 }
 #undef SVE_REGISTER_MAX_BYTES


### PR DESCRIPTION
a potential out-of-bondary access when the next start code isn't found in a SVE - for datasize < 2, for others - when the loop ends without finding the code and i == datasize (next iteration outside loop)