### PR TITLE
Revert unneeded check

### DIFF
--- a/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeAVX2.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeAVX2.cpp
@@ -49,10 +49,6 @@ size_t VulkanVideoDecoder::next_start_code<SIMD_ISA::AVX2>(const uint8_t *pdatai
             }
         } // main processing loop end
         m_BitBfr = (pdatain[i-2] << 8) | pdatain[i-1];
-        if (i >= datasize) {
-            found_start_code = false;
-            return datasize;
-        }
     }
     // process a tail (rest):
     uint32_t bfr = m_BitBfr;

--- a/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeAVX512.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeAVX512.cpp
@@ -53,10 +53,6 @@ size_t VulkanVideoDecoder::next_start_code<SIMD_ISA::AVX512>(const uint8_t *pdat
             }
         } // main processing loop end
         m_BitBfr = (pdatain[i-2] << 8) | pdatain[i-1];
-        if (i >= datasize) {
-            found_start_code = false;
-            return datasize;
-        }
     }
     // process a tail (rest):
     uint32_t bfr = m_BitBfr;

--- a/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeNEON.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeNEON.cpp
@@ -62,10 +62,6 @@ size_t VulkanVideoDecoder::next_start_code<SIMD_ISA::NEON>(const uint8_t *pdatai
             }
         } // main processing loop end
         m_BitBfr = (pdatain[i-2] << 8) | pdatain[i-1];
-        if (i >= datasize) {
-            found_start_code = false;
-            return datasize;
-        }
     }
     // process a tail (rest):
     uint32_t bfr = m_BitBfr;

--- a/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeSSSE3.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeSSSE3.cpp
@@ -47,10 +47,6 @@ size_t VulkanVideoDecoder::next_start_code<SIMD_ISA::SSSE3>(const uint8_t *pdata
             }
         } // main processing loop end
         m_BitBfr = (pdatain[i-2] << 8) | pdatain[i-1];
-        if (i >= datasize) {
-            found_start_code = false;
-            return datasize;
-        }
     }
     // process a tail (rest):
     uint32_t bfr = m_BitBfr;


### PR DESCRIPTION
The checks are redundant because the maximum possible value after the loop ends is `datasizeN - N`, loop step is `N` (I introduced them in a previous commit). Only the SVE-based code's change from the previous commit is required (left it)