### PR TITLE
Added 1-to-n transcoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,7 @@ endif()
 
     if(BUILD_DEMOS AND NOT DEFINED DEQP_TARGET)
         add_subdirectory(vk_video_decoder/demos)
+        add_subdirectory(vk_video_transcoder/demos)
     endif()
 endif()
 ############ VULKAN_VIDEO_DECODER_LIB ######################################

--- a/common/libs/VkCodecUtils/DecoderConfig.h
+++ b/common/libs/VkCodecUtils/DecoderConfig.h
@@ -78,6 +78,9 @@ struct DecoderConfig {
         enableHwLoadBalancing = false;
         selectVideoWithComputeQueue = false;
         noDeviceFallback = false;
+#if (_TRANSCODING)
+        enableVideoEncoder = true;
+#endif // _TRANSCODING
         outputy4m = true; // by default, use Y4M
         outputcrcPerFrame = false;
         outputcrc = false;
@@ -117,6 +120,9 @@ struct DecoderConfig {
                 [this](const char **argv, const ProgramArgs &a) {
                     showHelp(argv, a);
                     help = true;
+#if (!_TRANSCODING) // transcoding: should print encode info as well
+                    return false;
+#endif // !_TRANSCODING
                     return true;
                 }},
             {"--disableStrDemux", nullptr, 0, "Disable stream demuxing",
@@ -124,7 +130,12 @@ struct DecoderConfig {
                     enableStreamDemuxing = false;
                     return true;
                 }},
-            {"--codec", nullptr, 1, "Codec to use, if no stream auto-detect is in use",
+                {
+#if (!_TRANSCODING) // transcoding: to prevent overlap with encoder's codec option
+            "--codec", nullptr, 1, "Codec to use, if no stream auto-detect is in use",
+#else
+            "--codec-input", nullptr, 1, "Codec to decode",
+#endif // !_TRANSCODING
                 [this](const char **args, const ProgramArgs &a) {
                     if ((strcmp(args[0], "hevc") == 0) ||
                         (strcmp(args[0], "h265") == 0)) {
@@ -387,10 +398,14 @@ struct DecoderConfig {
                 (a.short_flag != nullptr && strcmp(argv[i], a.short_flag) == 0);
             });
             if (flag == spec.end()) {
+#if (!_TRANSCODING) // transcoding: should parse encode info after decode info as well
                 std::cerr << "Unknown argument \"" << argv[i] << "\"" << std::endl;
                 std::cout << std::endl;
                 showHelp(argv, spec);
                 return false;
+#else
+                continue;
+#endif // !_TRANSCODING
             }
 
             if (i + flag->numArgs >= argc) {
@@ -486,6 +501,9 @@ struct DecoderConfig {
     uint32_t enableHwLoadBalancing : 1;
     uint32_t selectVideoWithComputeQueue : 1;
     uint32_t noDeviceFallback : 1;
+#if (_TRANSCODING)
+    uint32_t enableVideoEncoder : 1;
+#endif // _TRANSCODING
     uint32_t outputy4m : 1;
     uint32_t outputcrc : 1;
     uint32_t outputcrcPerFrame : 1;

--- a/common/libs/VkCodecUtils/FrameProcessor.h
+++ b/common/libs/VkCodecUtils/FrameProcessor.h
@@ -24,6 +24,12 @@
 #include <vector>
 
 #include "VkCodecUtils/VkVideoRefCountBase.h"
+#if (_TRANSCODING)
+#include "VkCodecUtils/VulkanDecodedFrame.h"
+#include "VkCodecUtils/VulkanEncoderFrameProcessor.h"
+#include "VkCodecUtils/DecoderConfig.h"
+#include "VkVideoEncoder/VkEncoderConfig.h"
+#endif // _TRANSCODING
 
 class Shell;
 
@@ -66,6 +72,16 @@ public:
                          const VkSemaphore* pWaitSemaphores  = nullptr,
                          uint32_t           signalSemaphoreCount = 0,
                          const VkSemaphore* pSignalSemaphores = nullptr) = 0;
+#if (_TRANSCODING)
+    virtual bool OnFrameTranscoding( int32_t renderIndex,
+                         DecoderConfig* programConfig,
+                         VkSharedBaseObj<EncoderConfig>& encoderConfig,
+                         uint32_t           waitSemaphoreCount = 0,
+                         const VkSemaphore* pWaitSemaphores  = nullptr,
+                         uint32_t           signalSemaphoreCount = 0,
+                         const VkSemaphore* pSignalSemaphores = nullptr,
+                         VulkanDecodedFrame* pLastFrameDecoded = nullptr) = 0;
+#endif // _TRANSCODING
 
     uint64_t GetTimeDiffNanoseconds(bool updateStartTime = true)
     {

--- a/common/libs/VkCodecUtils/VkImageResource.h
+++ b/common/libs/VkCodecUtils/VkImageResource.h
@@ -309,9 +309,12 @@ public:
         // Fall back to first plane view if combined view is null (storage-only case)
         return m_imageViews[0] ? m_imageViews[0] : (m_numPlanes > 0 ? m_imageViews[1] : VK_NULL_HANDLE);
     }
-    VkImageView GetImageView() const {
-        // Fall back to first plane view if combined view is null (storage-only case)
-        return m_imageViews[0] ? m_imageViews[0] : (m_numPlanes > 0 ? m_imageViews[1] : VK_NULL_HANDLE);
+    VkImageView GetImageView(int i = 0) const {
+        if (i == 0) {
+            // Fall back to first plane view if combined view is null (storage-only case)
+            return m_imageViews[0] ? m_imageViews[0] : (m_numPlanes > 0 ? m_imageViews[1] : VK_NULL_HANDLE);
+        }
+        return m_imageViews[i];
     }
     uint32_t GetNumberOfPlanes() const { return m_numPlanes; }
     VkImageView GetPlaneImageView(uint32_t planeIndex = 0) const {

--- a/common/libs/VkCodecUtils/VkVideoQueue.h
+++ b/common/libs/VkCodecUtils/VkVideoQueue.h
@@ -20,6 +20,10 @@
 #include <stdint.h>
 #include <vulkan/vulkan.h>
 #include "VkCodecUtils/VkVideoRefCountBase.h"
+#if (_TRANSCODING)
+#include "VkCodecUtils/DecoderConfig.h"
+#include "VkVideoEncoder/VkEncoderConfig.h"
+#endif // _TRANSCODING
 
 /**
  * @class VkVideoQueue
@@ -148,7 +152,11 @@ public:
      * - `-1` if an error occurs or if the end of the stream is reached. In either case, decoding should
      *         be terminated or reset accordingly.
      */
-    virtual int32_t  GetNextFrame(FrameDataType* pNewFrame, bool* endOfStream) = 0;
+    virtual int32_t  GetNextFrame(FrameDataType* pNewFrame, bool* endOfStream
+    #if (_TRANSCODING)
+        , DecoderConfig* programConfig = nullptr, VkSharedBaseObj<EncoderConfig>* encoderConfig = nullptr
+    #endif // _TRANSCODING
+        ) = 0;
 
     /**
      * @brief Release a previously retrieved decoded frame.

--- a/common/libs/VkCodecUtils/VulkanDisplayFrame.h
+++ b/common/libs/VkCodecUtils/VulkanDisplayFrame.h
@@ -44,6 +44,9 @@ public:
     VkSemaphore consumerCompleteSemaphore; // If valid, the semaphore is signaled when the decoder or encoder is done decoding / encoding the frame.
     uint64_t frameCompleteDoneSemValue; // The semaphore is signaled by the decoder or the decoder's filter when this semaphore value has been reached.
     uint64_t frameConsumerDoneSemValue; // The semaphore is signaled by the consumer (graphics, compute or display) when this semaphore value has been reached.
+#if (_TRANSCODING)
+    VkSemaphore frameResizeSemaphore[16];
+#endif //_TRANSCODING
     VkQueryPool queryPool;                  // queryPool handle used for the video queries.
     int32_t startQueryId;                   // query Id used for the this frame.
     uint32_t numQueries;                    // usually one query per frame

--- a/common/libs/VkCodecUtils/VulkanFilterYuvCompute.cpp
+++ b/common/libs/VkCodecUtils/VulkanFilterYuvCompute.cpp
@@ -156,7 +156,11 @@ VkResult VulkanFilterYuvCompute::Create(const VulkanDeviceContext* vkDevCtx,
                                         const VkSamplerYcbcrConversionCreateInfo* pYcbcrConversionCreateInfo,
                                         const YcbcrPrimariesConstants* pYcbcrPrimariesConstants,
                                         const VkSamplerCreateInfo* pSamplerCreateInfo,
-                                        VkSharedBaseObj<VulkanFilter>& vulkanFilter)
+                                        VkSharedBaseObj<VulkanFilter>& vulkanFilter
+#ifdef _TRANSCODING
+                                        , const std::vector<Rectangle>& resizedResolutions
+#endif
+)
 {
 
     VkSharedBaseObj<VulkanFilterYuvCompute> yCbCrVulkanFilter(new VulkanFilterYuvCompute(vkDevCtx,
@@ -167,7 +171,11 @@ VkResult VulkanFilterYuvCompute::Create(const VulkanDeviceContext* vkDevCtx,
                                                                                          inputFormat,
                                                                                          outputFormat,
                                                                                          filterFlags,
-                                                                                         pYcbcrPrimariesConstants));
+                                                                                         pYcbcrPrimariesConstants
+#if (_TRANSCODING)
+                                                                                         , resizedResolutions
+#endif
+                                                                                         ));
 
     if (!yCbCrVulkanFilter) {
        return VK_ERROR_OUT_OF_HOST_MEMORY;
@@ -204,6 +212,17 @@ VkResult VulkanFilterYuvCompute::Init(const VkSamplerYcbcrConversionCreateInfo* 
          }
     }
 
+#if (_TRANSCODING)
+   if (m_filterType == RESIZE)
+   {
+        result = m_samplerResize.CreateVulkanSampler(m_vkDevCtx);
+        if (result != VK_SUCCESS) {
+            assert(!"ERROR: samplerResizeCreate!");
+            return result;
+        }
+   }
+#endif
+
     assert(m_queue != VK_NULL_HANDLE);
 
     result = InitDescriptorSetLayout(m_maxNumFrames);
@@ -226,6 +245,9 @@ VkResult VulkanFilterYuvCompute::Init(const VkSamplerYcbcrConversionCreateInfo* 
          break;
      case RGBA2YCBCR:
          computeShaderSize = InitRGBA2YCBCR(computeShader);
+         break;
+    case RESIZE:
+         computeShaderSize = InitResize(computeShader);
          break;
      default:
          assert(!"Invalid filter type");
@@ -266,6 +288,16 @@ VkResult VulkanFilterYuvCompute::InitDescriptorSetLayout(uint32_t maxNumFrames)
         pInputImmutableSamplers = nullptr;
     }
 
+    const VkSampler* pImmutableSamplersResize = VK_NULL_HANDLE;
+#if (_TRANSCODING)
+    VkSampler textureSampler;
+    if (m_resizedResolutions.size() > 0) {
+        textureSampler = m_samplerResize.GetSampler();
+        pImmutableSamplersResize = &textureSampler;
+        assert(pImmutableSamplersResize != VK_NULL_HANDLE);
+    }
+#endif
+
     std::vector<VkDescriptorSetLayoutBinding> setLayoutBindings;
 
     // Input bindings (either images or buffers)
@@ -280,11 +312,11 @@ VkResult VulkanFilterYuvCompute::InitDescriptorSetLayout(uint32_t maxNumFrames)
         setLayoutBindings.push_back(VkDescriptorSetLayoutBinding{ 3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr});
     } else {
         // Binding 0: Input image (read-only) - type depends on filter
-        setLayoutBindings.push_back(VkDescriptorSetLayoutBinding{ 0, inputType, 1, VK_SHADER_STAGE_COMPUTE_BIT, pInputImmutableSamplers});
+        setLayoutBindings.push_back(VkDescriptorSetLayoutBinding{ 0, inputType, 1, VK_SHADER_STAGE_COMPUTE_BIT, pImmutableSamplersResize ? nullptr : pInputImmutableSamplers});
         // Binding 1: Input image (read-only) Y plane of YCbCr Image
-        setLayoutBindings.push_back(VkDescriptorSetLayoutBinding{ 1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr});
+        setLayoutBindings.push_back(VkDescriptorSetLayoutBinding{ 1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE , 1, VK_SHADER_STAGE_COMPUTE_BIT, pImmutableSamplersResize });
         // Binding 2: Input image (read-only) Cb or CbCr plane
-        setLayoutBindings.push_back(VkDescriptorSetLayoutBinding{ 2, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr});
+        setLayoutBindings.push_back(VkDescriptorSetLayoutBinding{ 2, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, pImmutableSamplersResize });
         // Binding 3: Input image (read-only) Cr plane
         setLayoutBindings.push_back(VkDescriptorSetLayoutBinding{ 3, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr});
     }
@@ -2584,6 +2616,76 @@ size_t VulkanFilterYuvCompute::InitYCBCRCOPY(std::string& computeShader)
     return computeShader.size();
 }
 
+size_t VulkanFilterYuvCompute::InitResize(std::string& computeShader)
+{
+    // The compute filter uses two input images as separate planes
+    // Y (R) binding = 1
+    // CbCr (RG) binding = 2
+    // TODO: Add more YCbCr formats
+    m_inputImageAspects = VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT;
+
+    // The compute filter uses two output images as separate planes
+    // Y (R) binding = 5
+    // CbCr (RG) binding = 6
+    // TODO: Add more YCbCr formats
+    m_outputImageAspects = VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT;
+
+    std::stringstream shaderStr;
+    // Create compute pipeline
+    shaderStr << "#version 450\n"
+                        "layout(push_constant) uniform PushConstants {\n"
+                        "    uint srcImageLayer;\n"
+                        "    uint dstImageLayer;\n"
+                        "    uint width;\n"
+                        "    uint height;\n"
+                        "    float scalingFactorX;\n"
+                        "    float scalingFactorY;\n"
+                        "} pushConstants;\n"
+                        "\n"
+                        "layout (local_size_x = 16, local_size_y = 16) in;\n"
+                        " // TODO: use set and binding from the layout\n"
+                        " // TODO: use r16 for 16-bit formats\n"
+                        "layout (set = 0, binding = 1) uniform sampler2D texSampler;\n"
+                        "layout (set = 0, binding = 2) uniform sampler2D texSamplerUV;\n"
+                        " // TODO: use rgba16 for 16-bit formats\n"
+                        "layout (set = 0, binding = 5, r8) uniform  writeonly image2DArray outImageY;\n"
+                        " // TODO: use rg16 for 16-bit formats\n"
+                        "layout (set = 0, binding = 6, rg8) uniform writeonly image2DArray outImageCbCr;\n"
+                        "\n"
+                        "\n";
+
+    shaderStr <<
+        "void main()\n"
+        "{\n"
+        "    ivec2 uvpos = ivec2(gl_GlobalInvocationID.xy);\n"
+        "    ivec2 pos = uvpos *2; \n"
+        "    vec2 scalingFactor = vec2(pushConstants.scalingFactorX, pushConstants.scalingFactorY);\n"
+        "    vec2 sourcepos00 = vec2(vec2(pushConstants.scalingFactorX, pushConstants.scalingFactorY) * vec2(pos));\n"
+        "    vec2 sourcepos10 = vec2(vec2(pushConstants.scalingFactorX, pushConstants.scalingFactorY) * vec2(pos.x+1, pos.y));\n"
+        "    vec2 sourcepos01 = vec2(vec2(pushConstants.scalingFactorX, pushConstants.scalingFactorY) * vec2(pos.x, pos.y+1));\n"
+        "    vec2 sourcepos11 = vec2(vec2(pushConstants.scalingFactorX, pushConstants.scalingFactorY) * vec2(pos.x+1, pos.y+1));\n"
+        "\n"
+        "    // Read Y value from source Y plane and write it to destination Y plane\n"
+        "    float Y00 = texture(texSampler, sourcepos00).r;\n"
+        "    float Y10 = texture(texSampler, sourcepos10).r;\n"
+        "    float Y01 = texture(texSampler, sourcepos01).r;\n"
+        "    float Y11 = texture(texSampler, sourcepos11).r;\n"
+        "    imageStore(outImageY, ivec3(pos, pushConstants.dstImageLayer), vec4(Y00, 0, 0, 1));\n"
+        "    imageStore(outImageY, ivec3(ivec2(pos.x+1, pos.y), pushConstants.dstImageLayer), vec4(Y10, 0, 0, 1));\n"
+        "    imageStore(outImageY, ivec3(ivec2(pos.x, pos.y+1), pushConstants.dstImageLayer), vec4(Y01, 0, 0, 1));\n"
+        "    imageStore(outImageY, ivec3(ivec2(pos.x+1, pos.y+1), pushConstants.dstImageLayer), vec4(Y11, 0, 0, 1));\n"
+        "\n"
+        "    // Do the same for the CbCr plane, but remember about the 4:2:0 subsampling\n"
+        "    vec2 sourceposuv = ivec2(vec2(pushConstants.scalingFactorX, pushConstants.scalingFactorY) * vec2(uvpos));\n"
+        "    vec2 CbCr = texture(texSamplerUV, sourceposuv).rg;\n"
+        "    imageStore(outImageCbCr, ivec3(uvpos, pushConstants.dstImageLayer), vec4(CbCr, 0, 1));\n"
+        "}\n";
+
+    computeShader = shaderStr.str();
+    std::cout << "\nCompute Shader:\n" << computeShader;
+    return computeShader.size();
+}
+
 size_t VulkanFilterYuvCompute::InitYCBCRCLEAR(std::string& computeShader)
 {
     // The compute filter uses NO input images
@@ -3312,9 +3414,24 @@ VkResult VulkanFilterYuvCompute::RecordCommandBuffer(VkCommandBuffer cmdBuf,
         ivec2(int32_t width_, int32_t height_) : width(width_), height(height_) {}
     };
 
+#if(_TRANSCODING)
+        int numResizes = m_resizedResolutions.size();
+
+        for (int i = 0; i < numResizes; i++)
+        {
+            float resizedWidth =  m_resizedResolutions[i].width;
+            float resizedHeight =  m_resizedResolutions[i].height;
+#endif //_TRANSCODING
+
     struct PushConstants {
         uint32_t srcLayer;
         uint32_t dstLayer;
+#if(_TRANSCODING)
+            uint32_t width;
+            uint32_t height;
+            float scalingFactorX;
+            float scalingFactorY;
+#endif //_TRANSCODING
         ivec2    inputSize;
         ivec2    outputSize;
         ivec2    halfInputSize;    // Precomputed (inputSize + 1) / 2
@@ -3327,18 +3444,32 @@ VkResult VulkanFilterYuvCompute::RecordCommandBuffer(VkCommandBuffer cmdBuf,
         uint32_t crPitch;   // Cr plane pitch
     };
 
+#if (!_TRANSCODING)
     uint32_t inputWidth = inImageResourceInfo->codedExtent.width;
     uint32_t inputHeight = inImageResourceInfo->codedExtent.height;
     uint32_t outputWidth = outImageResourceInfo->codedExtent.width;
     uint32_t outputHeight = outImageResourceInfo->codedExtent.height;
+#endif
 
     PushConstants pushConstants = {
             inImageResourceInfo->baseArrayLayer, // Set the source layer index
+#if(_TRANSCODING)
+            outImageResourceInfo->baseArrayLayer + i,
+            inImageResourceInfo->codedExtent.width,
+            inImageResourceInfo->codedExtent.height,
+            inImageResourceInfo->codedExtent.width / resizedWidth,
+            inImageResourceInfo->codedExtent.height / resizedHeight,
+            ivec2(inImageResourceInfo->codedExtent.width, inImageResourceInfo->codedExtent.height),
+            ivec2(outImageResourceInfo->codedExtent.width, outImageResourceInfo->codedExtent.height),
+            ivec2((inImageResourceInfo->codedExtent.width + 1) / 2, (inImageResourceInfo->codedExtent.height + 1) / 2),
+            ivec2((outImageResourceInfo->codedExtent.width + 1) / 2, (outImageResourceInfo->codedExtent.height + 1) / 2),
+#else
             outImageResourceInfo->baseArrayLayer, // Set the destination layer index
             ivec2(inputWidth, inputHeight),
             ivec2(outputWidth, outputHeight),
             ivec2((inputWidth + 1) / 2, (inputHeight + 1) / 2),    // halfInputSize
             ivec2((outputWidth + 1) / 2, (outputHeight + 1) / 2),  // halfOutputSize
+#endif //_TRANSCODING
             0,  // yOffset - not used for image input
             0,  // cbOffset - not used for image input
             0,  // crOffset - not used for image input
@@ -3353,16 +3484,25 @@ VkResult VulkanFilterYuvCompute::RecordCommandBuffer(VkCommandBuffer cmdBuf,
                                  0,
                                  sizeof(PushConstants),
                                  &pushConstants);
-
+#if (_TRANSCODING)
+            const uint32_t yuv_scale_x = 2; // yuv420 & yuv 422 only
+            const uint32_t yuv_scale_y = 2; // yuv420 only
+            int numPixelsPerInvocationX = yuv_scale_x * m_workgroupSizeX;
+            int numPixelsPerInvocationY = yuv_scale_y * m_workgroupSizeY;
+            uint32_t numTotalInvocationsRoundedUpX = (resizedWidth + numPixelsPerInvocationX - 1) / numPixelsPerInvocationX;
+            uint32_t numTotalInvocationsRoundedUpY = (resizedHeight + numPixelsPerInvocationY  - 1) / numPixelsPerInvocationY;
+            m_vkDevCtx->CmdDispatch(cmdBuf, numTotalInvocationsRoundedUpX, numTotalInvocationsRoundedUpY, 1);
+        } // resize loop
+#else
     // Dispatch based on output format's chroma subsampling
     // 4:2:0 (NV12, P010, I420): dispatch at (width/2, height/2) - each thread handles 2x2 luma
-    // 4:2:2 (NV16, P210): dispatch at (width/2, height) - each thread handles 2x1 luma  
+    // 4:2:2 (NV16, P210): dispatch at (width/2, height) - each thread handles 2x1 luma
     // 4:4:4 (YUV444): dispatch at (width, height) - each thread handles 1x1 luma
     // Packed formats (e.g. Y410 / A2B10G10R10): outputMpInfo is null but it's 4:4:4 → ratio 1
     const VkMpFormatInfo* outputMpInfo = YcbcrVkFormatInfo(m_outputFormat);
     const uint32_t chromaHorzRatio = (outputMpInfo != nullptr) ? (1 << outputMpInfo->planesLayout.secondaryPlaneSubsampledX) : 1;
     const uint32_t chromaVertRatio = (outputMpInfo != nullptr) ? (1 << outputMpInfo->planesLayout.secondaryPlaneSubsampledY) : 1;
-    
+
     const uint32_t dispatchWidth = (pushConstants.outputSize.width + chromaHorzRatio - 1) / chromaHorzRatio;
     const uint32_t dispatchHeight = (pushConstants.outputSize.height + chromaVertRatio - 1) / chromaVertRatio;
 
@@ -3395,6 +3535,7 @@ VkResult VulkanFilterYuvCompute::RecordCommandBuffer(VkCommandBuffer cmdBuf,
         depInfo.pImageMemoryBarriers = &imgBarrier;
         m_vkDevCtx->CmdPipelineBarrier2KHR(cmdBuf, &depInfo);
     }
+#endif // _TRANSCODING
 
     return VK_SUCCESS;
 }

--- a/common/libs/VkCodecUtils/VulkanFilterYuvCompute.h
+++ b/common/libs/VkCodecUtils/VulkanFilterYuvCompute.h
@@ -587,6 +587,12 @@ public:
          * optimal → linear for host access)
          */
         XFER_IMAGE_TO_IMAGE,
+        RESIZE,
+    };
+
+    struct Rectangle {
+        int width = 0;
+        int height = 0;
     };
     
     // =========================================================================
@@ -729,7 +735,11 @@ public:
                            const VkSamplerYcbcrConversionCreateInfo* pYcbcrConversionCreateInfo,
                            const YcbcrPrimariesConstants* pYcbcrPrimariesConstants,
                            const VkSamplerCreateInfo* pSamplerCreateInfo,
-                           VkSharedBaseObj<VulkanFilter>& vulkanFilter);
+                           VkSharedBaseObj<VulkanFilter>& vulkanFilter
+#ifdef _TRANSCODING
+                            , const std::vector<Rectangle>& resizedResolutions = {}
+#endif
+                            );
 
     /**
      * @brief Create a transfer-only filter instance
@@ -783,7 +793,11 @@ public:
                            VkFormat inputFormat,
                            VkFormat outputFormat,
                            uint32_t filterFlags,  // FilterFlags bitmask
-                           const YcbcrPrimariesConstants* pYcbcrPrimariesConstants)
+                           const YcbcrPrimariesConstants* pYcbcrPrimariesConstants
+#if (_TRANSCODING)
+                           , const std::vector<Rectangle>& resizedResolutions = {}
+#endif
+                           )
         : VulkanFilter(vkDevCtx, queueFamilyIndex, queueIndex)
         , m_filterType(filterType)
         , m_inputFormat(inputFormat)
@@ -803,6 +817,9 @@ public:
                                 VK_IMAGE_ASPECT_PLANE_1_BIT |
                                 VK_IMAGE_ASPECT_PLANE_2_BIT)
         , m_filterFlags(filterFlags)
+#if (_TRANSCODING)
+        , m_resizedResolutions(resizedResolutions)
+#endif
         , m_inputEnableMsbToLsbShift((filterFlags & FLAG_INPUT_MSB_TO_LSB_SHIFT) != 0)
         , m_outputEnableLsbToMsbShift((filterFlags & FLAG_OUTPUT_LSB_TO_MSB_SHIFT) != 0)
         , m_enableRowAndColumnReplication((filterFlags & (FLAG_ENABLE_ROW_COLUMN_REPLICATION_ONE | FLAG_ENABLE_ROW_COLUMN_REPLICATION_ALL)) != 0)
@@ -1258,6 +1275,7 @@ protected:
      * @return Size of the generated shader code in bytes
      */
     size_t InitYCBCR2RGBA(std::string& computeShader);
+    size_t InitResize(std::string& computeShader);
 
     /**
      * @brief Initializes GLSL shader for RGBA to YCbCr conversion
@@ -1284,11 +1302,17 @@ protected:
     uint32_t                                 m_maxNumFrames;
     const YcbcrPrimariesConstants            m_ycbcrPrimariesConstants;
     VulkanSamplerYcbcrConversion             m_samplerYcbcrConversion;
+#ifdef _TRANSCODING
+    VulkanSamplerResize                      m_samplerResize;
+#endif
     VulkanDescriptorSetLayout                m_descriptorSetLayout;
     VulkanComputePipeline                    m_computePipeline;
     VkImageAspectFlags                       m_inputImageAspects;
     VkImageAspectFlags                       m_outputImageAspects;
     uint32_t                                 m_filterFlags;  // FilterFlags bitmask
+#if (_TRANSCODING)
+    std::vector<Rectangle>                   m_resizedResolutions;
+#endif
     uint32_t                                 m_inputEnableMsbToLsbShift : 1;
     uint32_t                                 m_outputEnableLsbToMsbShift : 1;
     uint32_t                                 m_enableRowAndColumnReplication : 1;

--- a/common/libs/VkCodecUtils/VulkanFrame.cpp
+++ b/common/libs/VkCodecUtils/VulkanFrame.cpp
@@ -26,6 +26,9 @@
 #include "VkCodecUtils/VulkanVideoUtils.h"
 #include "VulkanFrame.h"
 #include "VkVideoCore/DecodeFrameBufferIf.h"
+#if (_TRANSCODING)
+#include "VkVideoEncoder/VkVideoEncoder.h"
+#endif // _TRANSCODING
 #include "VkCodecUtils/VulkanSemaphoreDump.h"
 
 template<class FrameDataType>
@@ -300,6 +303,37 @@ bool VulkanFrame<FrameDataType>::OnKey(Key key)
     return true;
 }
 
+#if (_TRANSCODING)
+static int InitPreset(VkSharedBaseObj<EncoderConfig>& encoderConfig)
+{
+    if (encoderConfig->encodingProfile == EncoderConfig::LOW_LATENCY_STREAMING)
+    {
+        encoderConfig->rateControlMode = VkVideoEncodeRateControlModeFlagBitsKHR::VK_VIDEO_ENCODE_RATE_CONTROL_MODE_CBR_BIT_KHR;
+        encoderConfig->gopStructure.SetConsecutiveBFrameCount(0);
+        encoderConfig->gopStructure.SetGopFrameCount((uint16_t)-1);
+        encoderConfig->gopStructure.SetIdrPeriod((uint16_t)-1);
+        encoderConfig->gopStructure.SetLastFrameType(VkVideoGopStructure::FrameType::FRAME_TYPE_P); // ? set right value
+        // encoderConfig->encodeUsageHints = VK_VIDEO_ENCODE_USAGE_STREAMING_BIT_KHR;
+        // encoderConfig->encodeContentHints = VK_VIDEO_ENCODE_CONTENT_RENDERED_BIT_KHR;
+        encoderConfig->tuningMode = VK_VIDEO_ENCODE_TUNING_MODE_LOW_LATENCY_KHR;
+        // encoderConfig->gopStructure.SetTemporalLayerCount(3);
+    }
+    else if (encoderConfig->encodingProfile == EncoderConfig::ARCHIVING)
+    {
+        encoderConfig->rateControlMode = VkVideoEncodeRateControlModeFlagBitsKHR::VK_VIDEO_ENCODE_RATE_CONTROL_MODE_VBR_BIT_KHR;
+        encoderConfig->maxBitrate = (uint32_t)(1.2f * encoderConfig->averageBitrate); // This is used in Variable Bit Rate (VBR) mode and is ignored for Constant Bit Rate (CBR) mode.
+        encoderConfig->gopStructure.SetConsecutiveBFrameCount(3);
+        encoderConfig->gopStructure.SetIdrPeriod(MAX_GOP_SIZE);
+        encoderConfig->gopStructure.SetGopFrameCount(MAX_GOP_SIZE);
+        encoderConfig->gopStructure.SetTemporalLayerCount(1);
+        // encoderConfig->encodeUsageHints = VK_VIDEO_ENCODE_USAGE_RECORDING_BIT_KHR;
+        // encoderConfig->encodeContentHints = VK_VIDEO_ENCODE_CONTENT_RENDERED_BIT_KHR;
+        encoderConfig->tuningMode = VK_VIDEO_ENCODE_TUNING_MODE_HIGH_QUALITY_KHR;
+    };
+    return 0;
+}
+#endif // _TRANSCODING
+
 template<class FrameDataType>
 bool VulkanFrame<FrameDataType>::OnFrame( int32_t renderIndex,
                           uint32_t           waitSemaphoreCount,
@@ -428,6 +462,7 @@ bool VulkanFrame<FrameDataType>::OnFrame( int32_t renderIndex,
                                 pSignalSemaphores,
                                 pLastDecodedFrame);
 
+    // VkImageLastDecodedFrame()
 
     if (VK_SUCCESS != result) {
         return false;
@@ -435,6 +470,143 @@ bool VulkanFrame<FrameDataType>::OnFrame( int32_t renderIndex,
 
     return continueLoop;
 }
+
+#if (_TRANSCODING)
+template<class FrameDataType>
+bool VulkanFrame<FrameDataType>::OnFrameTranscoding( int32_t renderIndex,
+                          DecoderConfig* decoderConfig,
+                          VkSharedBaseObj<EncoderConfig>& encoderConfig,
+                          uint32_t           waitSemaphoreCount,
+                          const VkSemaphore* pWaitSemaphores,
+                          uint32_t           signalSemaphoreCount,
+                          const VkSemaphore* pSignalSemaphores,
+                          VulkanDecodedFrame* pLastDecodedFrameRet)
+{
+    // must not be used by encoder
+    int isFunctionUsed = 0;
+    isFunctionUsed++;
+    assert(isFunctionUsed == 0);//, "must not be used by encoder");
+    return false;
+}
+
+template<>
+bool VulkanFrame<VulkanDecodedFrame>::OnFrameTranscoding( int32_t renderIndex,
+                          DecoderConfig* decoderConfig,
+                          VkSharedBaseObj<EncoderConfig>& encoderConfig,
+                          uint32_t           waitSemaphoreCount,
+                          const VkSemaphore* pWaitSemaphores,
+                          uint32_t           signalSemaphoreCount,
+                          const VkSemaphore* pSignalSemaphores,
+                          VulkanDecodedFrame* pLastDecodedFrameRet)
+{
+    InitPreset(encoderConfig);
+    bool continueLoop = true;
+    const bool dumpDebug = false;
+    const bool trainFrame = (renderIndex < 0);
+    const bool gfxRendererIsEnabled = (m_videoRenderer != nullptr);
+    m_frameCount++;
+
+    if (dumpDebug == false) {
+        bool displayTimeNow = false;
+        float fps = GetFrameRateFps(displayTimeNow);
+        if (displayTimeNow) {
+            std::cout << "\t\tFrame " << m_frameCount << ", FPS: " << fps << std::endl;
+        }
+    } else {
+        uint64_t timeDiffNanoSec = GetTimeDiffNanoseconds();
+        std::cout << "\t\t Time nanoseconds: " << timeDiffNanoSec <<
+                     " milliseconds: " << timeDiffNanoSec / 1000 <<
+                     " rate: " << 1000000000.0 / timeDiffNanoSec << std::endl;
+    }
+
+    VulkanDecodedFrame* pLastDecodedFrame = nullptr;
+    // FrameDataType* pLastDecodedFrame = nullptr;
+
+    if ((m_videoQueue->GetWidth() > 0) && !trainFrame) {
+
+        pLastDecodedFrame = &m_frameData[m_frameDataIndex];
+
+        // Graphics and present stages are not enabled.
+        // Make sure the frame complete query or fence are signaled (video frame is processed) before returning the frame.
+        if (false && (gfxRendererIsEnabled == false) && (pLastDecodedFrame != nullptr)) {
+
+            if (pLastDecodedFrame->queryPool != VK_NULL_HANDLE) {
+                auto startTime = std::chrono::steady_clock::now();
+                VkQueryResultStatusKHR decodeStatus;
+                VkResult result = m_vkDevCtx->GetQueryPoolResults(*m_vkDevCtx,
+                                                 pLastDecodedFrame->queryPool,
+                                                 pLastDecodedFrame->startQueryId,
+                                                 1,
+                                                 sizeof(decodeStatus),
+                                                 &decodeStatus,
+                                                 sizeof(decodeStatus),
+                                                 VK_QUERY_RESULT_WITH_STATUS_BIT_KHR | VK_QUERY_RESULT_WAIT_BIT);
+
+                assert(result == VK_SUCCESS);
+                assert(decodeStatus == VK_QUERY_RESULT_STATUS_COMPLETE_KHR);
+                auto deltaTime = std::chrono::steady_clock::now() - startTime;
+                auto diffMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(deltaTime);
+                auto diffMicroseconds = std::chrono::duration_cast<std::chrono::microseconds>(deltaTime);
+                if (dumpDebug) {
+                    std::cout << pLastDecodedFrame->pictureIndex << ": frameWaitTime: " <<
+                                 diffMilliseconds.count() << "." << diffMicroseconds.count() << " mSec" << std::endl;
+                }
+            } else if (pLastDecodedFrame->frameCompleteFence != VkFence()) {
+                VkResult result = m_vkDevCtx->WaitForFences(*m_vkDevCtx, 1, &pLastDecodedFrame->frameCompleteFence, true, 100 * 1000 * 1000 /* 100 mSec */);
+                assert(result == VK_SUCCESS);
+                if (result != VK_SUCCESS) {
+                    fprintf(stderr, "\nERROR: WaitForFences() result: 0x%x\n", result);
+                }
+                result = m_vkDevCtx->GetFenceStatus(*m_vkDevCtx, pLastDecodedFrame->frameCompleteFence);
+                assert(result == VK_SUCCESS);
+                if (result != VK_SUCCESS) {
+                    fprintf(stderr, "\nERROR: GetFenceStatus() result: 0x%x\n", result);
+                }
+            }
+        }
+
+        m_videoQueue->ReleaseFrame(pLastDecodedFrame);
+
+        pLastDecodedFrame->Reset();
+
+        bool endOfStream = false;
+        int32_t numVideoFrames = 0;
+
+        if (pLastDecodedFrame) {
+            numVideoFrames = m_videoQueue->GetNextFrame(pLastDecodedFrame, &endOfStream, decoderConfig, &encoderConfig);
+        }
+        if (endOfStream && (numVideoFrames < 0)) {
+            continueLoop = false;
+            bool displayTimeNow = true;
+            float fps = GetFrameRateFps(displayTimeNow);
+            if (displayTimeNow) {
+                std::cout << "\t\tFrame " << m_frameCount << ", FPS: " << fps << std::endl;
+            }
+        }
+    }
+
+    if (gfxRendererIsEnabled == false) {
+        m_frameDataIndex = (m_frameDataIndex + 1) % m_frameData.size();
+        return continueLoop;
+    }
+
+    VkResult result = DrawFrame(renderIndex,
+                                waitSemaphoreCount,
+                                pWaitSemaphores,
+                                signalSemaphoreCount,
+                                pSignalSemaphores,
+                                pLastDecodedFrame);
+
+    // VkImageLastDecodedFrame()
+
+
+    if (VK_SUCCESS != result) {
+        return false;
+    }
+
+    return continueLoop;
+}
+#endif // _TRANSCODING
 
 template<class FrameDataType>
 VkResult VulkanFrame<FrameDataType>::DrawFrame( int32_t            renderIndex,

--- a/common/libs/VkCodecUtils/VulkanFrame.h
+++ b/common/libs/VkCodecUtils/VulkanFrame.h
@@ -50,6 +50,16 @@ public:
                           uint32_t           signalSemaphoreCount = 0,
                           const VkSemaphore* pSignalSemaphores = nullptr);
 
+#if (_TRANSCODING)
+    virtual bool OnFrameTranscoding(int32_t  renderIndex,
+                          DecoderConfig* programConfig,
+                          VkSharedBaseObj<EncoderConfig>& encoderConfig,
+                          uint32_t           waitSemaphoreCount = 0,
+                          const VkSemaphore* pWaitSemaphores  = nullptr,
+                          uint32_t           signalSemaphoreCount = 0,
+                          const VkSemaphore* pSignalSemaphores = nullptr,
+                          VulkanDecodedFrame* pLastFrameDecoded = nullptr);
+#endif // _TRANSCODING
 
     VkResult DrawFrame( int32_t           renderIndex,
                        uint32_t           waitSemaphoreCount,

--- a/common/libs/VkCodecUtils/VulkanSamplerYcbcrConversion.h
+++ b/common/libs/VkCodecUtils/VulkanSamplerYcbcrConversion.h
@@ -20,6 +20,7 @@
 #include <vulkan_interfaces.h>
 #include "VkCodecUtils/VulkanDeviceContext.h"
 #include "VkCodecUtils/VulkanSamplerYcbcrConversion.h"
+#include "vulkan/vulkan_core.h"
 
 class VulkanSamplerYcbcrConversion {
 
@@ -102,5 +103,58 @@ private:
     VkSamplerYcbcrConversion           m_samplerYcbcrConversion;
     VkSampler                          m_sampler;
 };
+
+#if (_TRANSCODING)
+class VulkanSamplerResize {
+
+public:
+    ~VulkanSamplerResize () {
+        DestroyVulkanSamplerResize();
+    }
+
+    void DestroyVulkanSamplerResize() {
+        if (m_samplerResize) {
+            m_vkDevCtx->DestroySampler(*m_vkDevCtx, m_samplerResize, nullptr);
+        }
+        m_samplerResize = VkSampler(0);
+    }
+
+    VkSampler GetSampler() const {
+        return m_samplerResize;
+    }
+
+    VkResult CreateVulkanSampler(const VulkanDeviceContext* vkDevCtx,
+                                 const VkSamplerCreateInfo* pSamplerCreateInfo = NULL) {
+        m_vkDevCtx = const_cast<VulkanDeviceContext*>(vkDevCtx);
+        VkSamplerCreateInfo samplerInfo{};
+        samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        samplerInfo.magFilter = VK_FILTER_LINEAR;
+        samplerInfo.minFilter = VK_FILTER_LINEAR;
+        samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        samplerInfo.anisotropyEnable = VK_FALSE; //VK_TRUE;
+        samplerInfo.maxAnisotropy = 1.0f; //m_vkDevCtx->GetMaxAnisotropy();
+        samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+        samplerInfo.unnormalizedCoordinates = VK_FALSE;
+        samplerInfo.compareEnable = VK_FALSE;
+        samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS;
+        samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+        samplerInfo.mipLodBias = 0.0f;
+        samplerInfo.minLod = 0.0f;
+        samplerInfo.maxLod = 0.0f;
+        samplerInfo.pNext = NULL;
+        if (m_vkDevCtx->CreateSampler(*m_vkDevCtx, &samplerInfo, nullptr, &m_samplerResize) != VK_SUCCESS) {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        return VK_SUCCESS;
+    }
+
+private:
+    VkSampler m_samplerResize{VK_NULL_HANDLE};
+    VulkanDeviceContext* m_vkDevCtx{nullptr};
+    VkSamplerCreateInfo m_samplerInfo{};
+};
+#endif // (_TRANSCODING)
 
 #endif /* _VULKANSAMPLERYCBCRCONVERSION_H_ */

--- a/common/libs/VkCodecUtils/VulkanVideoDisplayQueue.h
+++ b/common/libs/VkCodecUtils/VulkanVideoDisplayQueue.h
@@ -22,6 +22,10 @@
 #include <condition_variable>
 #include "VkCodecUtils/VkVideoQueue.h"
 #include "VkCodecUtils/VkThreadSafeQueue.h"
+#if (_TRANSCODING)
+#include "VkCodecUtils/DecoderConfig.h"
+#include "VkVideoEncoder/VkEncoderConfig.h"
+#endif // _TRANSCODING
 
 template<class FrameDataType>
 class VulkanVideoDisplayQueue : public VkVideoQueue<FrameDataType> {
@@ -39,7 +43,11 @@ public:
 
     virtual uint32_t GetProfileIdc() const { return 0; }
     virtual VkExtent3D GetVideoExtent() const;
-    virtual int32_t GetNextFrame(FrameDataType* pFrame, bool* endOfStream);
+    virtual int32_t GetNextFrame(FrameDataType* pFrame, bool* endOfStream
+#if (_TRANSCODING)
+        , DecoderConfig* programConfig, VkSharedBaseObj<EncoderConfig>* encoderConfig
+#endif // _TRANSCODING
+    );
     virtual int32_t ReleaseFrame(FrameDataType* pDisplayedFrame);
 
     static VkSharedBaseObj<VulkanVideoDisplayQueue>& invalidVulkanVideoDisplayQueue;
@@ -159,7 +167,11 @@ int32_t VulkanVideoDisplayQueue<FrameDataType>::EnqueueFrame(FrameDataType* pFra
 }
 
 template<class FrameDataType>
-int32_t VulkanVideoDisplayQueue<FrameDataType>::GetNextFrame(FrameDataType* pFrame, bool* endOfStream)
+int32_t VulkanVideoDisplayQueue<FrameDataType>::GetNextFrame(FrameDataType* pFrame, bool* endOfStream
+#if (_TRANSCODING)
+    , DecoderConfig* programConfig, VkSharedBaseObj<EncoderConfig>* encoderConfig
+#endif // _TRANSCODING
+)
 {
     if (m_exitQueueRequested) {
         m_queue.SetFlushAndExit();

--- a/common/libs/VkCodecUtils/VulkanVideoProcessor.cpp
+++ b/common/libs/VkCodecUtils/VulkanVideoProcessor.cpp
@@ -91,9 +91,11 @@ int32_t VulkanVideoProcessor::Initialize(const VulkanDeviceContext* vkDevCtx,
     m_frameToFile = frameToFile;
 
     uint32_t enableDecoderFeatures = 0;
+#if (!_TRANSCODING)
     if (!!m_frameToFile) {
         enableDecoderFeatures |= VkVideoDecoder::ENABLE_LINEAR_OUTPUT;
     }
+#endif // !_TRANSCODING
 
     if (enableHwLoadBalancing) {
         enableDecoderFeatures |= VkVideoDecoder::ENABLE_HW_LOAD_BALANCING;
@@ -269,6 +271,28 @@ void VulkanVideoProcessor::FlushAsyncFrameWrites()
         m_dumpPool.flush();
     }
 }
+
+#if (_TRANSCODING)
+int32_t VulkanVideoProcessor::GetCodedHeight()  const
+{
+    return m_vkVideoDecoder->GetVideoFormatInfo()->coded_height;
+}
+
+int32_t VulkanVideoProcessor::GetCodedWidth()  const
+{
+    return m_vkVideoDecoder->GetVideoFormatInfo()->coded_width;
+}
+
+uint32_t VulkanVideoProcessor::GetFrameRate()  const
+{
+    return (m_vkVideoDecoder->GetVideoFormatInfo()->frame_rate.denominator) |  (m_vkVideoDecoder->GetVideoFormatInfo()->frame_rate.numerator << 14);
+}
+
+uint32_t VulkanVideoProcessor::GetFramesCount()  const
+{
+    return m_maxFrameCount;
+}
+#endif //_TRANSCODING
 
 void VulkanVideoProcessor::Deinit()
 {
@@ -671,11 +695,45 @@ int32_t VulkanVideoProcessor::ParserProcessNextDataChunk()
     return retValue;
 }
 
-int32_t VulkanVideoProcessor::GetNextFrame(VulkanDecodedFrame* pFrame, bool* endOfStream)
+#if (_TRANSCODING)
+static void setGeneratedOutputFileName(DecoderConfig* programConfig, VkSharedBaseObj<EncoderConfig>& encoderConfig)
+{
+    std::string filename = std::string{programConfig->videoFileName};
+    size_t filePath = filename.rfind("/");
+    if (filePath == std::string::npos) filePath = filename.rfind("\\");
+    if (filePath == std::string::npos) filePath = 0; else filePath += 1;
+    filename = filename.substr(filePath, filename.size() - 1);
+    size_t fileExtension = filename.rfind(".");
+    filename = filename.substr(0, fileExtension);
+    std::string fileFormat = encoderConfig->codec == VkVideoCodecOperationFlagBitsKHR::VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR ? ".264" : ".265";
+    std::string generatedName = filename +
+                                "_" + std::to_string(encoderConfig->encodeHeight) +  "p" +
+                                "_p" + std::to_string(encoderConfig->qualityLevel + 1) +
+                                "_vbv" + std::to_string(encoderConfig->vbvbufratio) +  "_" +
+                                std::to_string(encoderConfig->averageBitrate>>20) +  "Mbps";
+    encoderConfig->outputFileHandler.SetFileName((generatedName + fileFormat).c_str());
+    for (int i = 0; i < encoderConfig->numEncoderResizedOutputs; i++)
+    {
+        encoderConfig->resizedOutputFileHandler[i].SetFileName((generatedName + "_" + std::to_string(i) + fileFormat).c_str());
+    }
+}
+#endif
+
+int32_t VulkanVideoProcessor::GetNextFrame(VulkanDecodedFrame* pFrame, bool* endOfStream
+#if (_TRANSCODING)
+    , DecoderConfig* programConfig, VkSharedBaseObj<EncoderConfig>* encoderConfig
+#endif
+)
 {
     // The below call to DequeueDecodedPicture allows returning the next frame without parsing of the stream.
     // Parsing is only done when there are no more frames in the queue.
     int32_t framesInQueue = m_vkVideoFrameBuffer->DequeueDecodedPicture(pFrame);
+
+#if (_TRANSCODING)
+    const int numberOfEncoders = std::max(1, (*encoderConfig)->numEncoderResizedOutputs);
+    m_vkVideoDecoder->m_numResizes = (*encoderConfig)->numEncoderResizedOutputs;
+    m_vkVideoDecoder->m_resizeResolution = (*encoderConfig)->resizedOutputResolution;
+#endif
 
     // Loop until a frame (or more) is parsed and added to the queue.
     while ((framesInQueue == 0) && !m_videoStreamsCompleted) {
@@ -691,11 +749,49 @@ int32_t VulkanVideoProcessor::GetNextFrame(VulkanDecodedFrame* pFrame, bool* end
 #if !defined(VK_VIDEO_NO_STDOUT_INFO)
             DumpVideoFormat(m_vkVideoDecoder->GetVideoFormatInfo(), true);
 #endif
+#if (_TRANSCODING)
+            {
+                (*encoderConfig)->encodeWidth = (*encoderConfig)->encodeMaxWidth = GetWidth();
+                (*encoderConfig)->encodeHeight = (*encoderConfig)->encodeMaxHeight = GetHeight();
+                (*encoderConfig)->input.width = GetCodedWidth();
+                (*encoderConfig)->input.height = GetCodedHeight();
+                setGeneratedOutputFileName(programConfig, *encoderConfig);
+                uint32_t frameRate = GetFrameRate();
+                (*encoderConfig)->numFrames = GetFramesCount();
+                (*encoderConfig)->frameRateDenominator = frameRate & ((1 << 14) - 1);
+                (*encoderConfig)->frameRateNumerator = frameRate >> 14;
+                m_vkVideoEncoder.resize(numberOfEncoders);
+                int i = 0;
+                do {
+                    if ((*encoderConfig)->numEncoderResizedOutputs > 0) {
+                        (*encoderConfig)->input.width = (*encoderConfig)->resizedOutputResolution[i].width;
+                        (*encoderConfig)->input.height = (*encoderConfig)->resizedOutputResolution[i].height;
+                        (*encoderConfig)->encodeWidth = (*encoderConfig)->encodeMaxWidth = (*encoderConfig)->resizedOutputResolution[i].width;
+                        (*encoderConfig)->encodeHeight = (*encoderConfig)->encodeMaxHeight = (*encoderConfig)->resizedOutputResolution[i].height;
+                    }
+                    (*encoderConfig)->InitializeParameters();
+                    VkResult result = VkVideoEncoder::CreateVideoEncoder(m_vkDevCtx, *encoderConfig, m_vkVideoEncoder[i]);
+                    assert(result == VK_SUCCESS);
+                    i++;
+                } while (i < numberOfEncoders);
+            }
+#endif //_TRANSCODING
         }
 
+#if (!_TRANSCODING)
         if (m_frameToFile) {
             OutputFrameToFile(pFrame);
         }
+#else
+        std::vector<VkSharedBaseObj<VkVideoEncoder::VkVideoEncodeFrameInfo>> encodeFrameInfo(numberOfEncoders);
+        int i = 0;
+        do {
+            m_vkVideoEncoder[i]->GetAvailablePoolNode(encodeFrameInfo[i]);
+            assert(encodeFrameInfo[i]);
+            m_vkVideoEncoder[i]->LoadNextFrameDecoded(encodeFrameInfo[i], pFrame, i);
+            i++;
+        } while (i < numberOfEncoders);
+#endif // !_TRANSCODING
 
         m_videoFrameNum++;
     }

--- a/common/libs/VkCodecUtils/VulkanVideoProcessor.h
+++ b/common/libs/VkCodecUtils/VulkanVideoProcessor.h
@@ -24,6 +24,10 @@
 #include "VkVideoFrameOutput.h"
 #include "VkCodecUtils/VkVideoDumpPool.h"
 
+#if (_TRANSCODING)
+#include "VkVideoEncoder/VkVideoEncoder.h"
+#include <vector>
+#endif //_TRANSCODING
 // Forward declarations
 class VulkanDeviceContext;
 struct VkMpFormatInfo;
@@ -38,7 +42,18 @@ public:
     virtual uint32_t GetProfileIdc() const;
     virtual VkFormat GetFrameImageFormat()  const;
     virtual VkExtent3D GetVideoExtent() const;
-    virtual int32_t GetNextFrame(VulkanDecodedFrame* pFrame, bool* endOfStream);
+    virtual int32_t GetNextFrame(VulkanDecodedFrame* pFrame, bool* endOfStream
+#if (_TRANSCODING)
+        , DecoderConfig* programConfig = nullptr, VkSharedBaseObj<EncoderConfig>* encoderConfig = nullptr
+    #endif // _TRANSCODING
+);
+#if (_TRANSCODING)
+    virtual int32_t GetCodedWidth()    const;
+    virtual int32_t GetCodedHeight()   const;
+    virtual uint32_t GetFrameRate() const;
+    virtual uint32_t GetFramesCount() const;
+#endif // _TRANSCODING
+
     virtual int32_t ReleaseFrame(VulkanDecodedFrame* pDisplayedFrame);
 
     static VkSharedBaseObj<VulkanVideoProcessor>& invalidVulkanVideoProcessor;
@@ -88,6 +103,9 @@ private:
           m_videoStreamDemuxer()
         , m_vkVideoFrameBuffer()
         , m_vkVideoDecoder()
+#if (_TRANSCODING)
+        , m_vkVideoEncoder()
+#endif // _TRANSCODING
         , m_vkParser()
         , m_frameToFile()
         , m_currentBitstreamOffset(0)
@@ -118,11 +136,21 @@ public:
 
     bool StreamCompleted();
 
+#if (_TRANSCODING)
+public:
+    VkSharedBaseObj<VkVideoEncoder> getEncoder(int imgLayerIdx = 0) const {
+        return m_vkVideoEncoder[imgLayerIdx];
+    };
+#endif // _TRANSCODING
+
 private:
     const VulkanDeviceContext* m_vkDevCtx;
     VkSharedBaseObj<VideoStreamDemuxer> m_videoStreamDemuxer;
     VkSharedBaseObj<VulkanVideoFrameBuffer> m_vkVideoFrameBuffer;
     VkSharedBaseObj<VkVideoDecoder> m_vkVideoDecoder;
+#if (_TRANSCODING)
+    std::vector<VkSharedBaseObj<VkVideoEncoder>> m_vkVideoEncoder;
+#endif // _TRANSCODING
     VkSharedBaseObj<IVulkanVideoParser> m_vkParser;
     VkSharedBaseObj<VkVideoFrameOutput> m_frameToFile;
     VkVideoDumpPool m_dumpPool;

--- a/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
+++ b/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
@@ -340,11 +340,13 @@ int32_t VkVideoDecoder::StartVideoSequence(VkParserDetectedVideoFormat* pVideoFo
     }
     m_numImageTypesEnabled |= DecodeFrameBufferIf::IMAGE_TYPE_MASK_DECODE_OUT;
 
+#if (!_TRANSCODING)
     if(!(videoCapabilities.flags & VK_VIDEO_CAPABILITY_SEPARATE_REFERENCE_IMAGES_BIT_KHR)) {
         // The implementation does not support individual images for DPB and so must use arrays
         m_useImageArray = VK_TRUE;
         m_useImageViewArray = VK_FALSE;
     }
+#endif //_TRANSCODING
 
     if (m_enableDecodeComputeFilter) {
 
@@ -399,7 +401,11 @@ int32_t VkVideoDecoder::StartVideoSequence(VkParserDetectedVideoFormat* pVideoFo
                                                 &ycbcrConversionCreateInfo,
                                                 &ycbcrPrimariesConstants,
                                                 &samplerInfo,
-                                                m_yuvFilter);
+                                                m_yuvFilter
+#if (_TRANSCODING)
+                                                , m_resizeResolution
+#endif
+                                            );
         if (result == VK_SUCCESS) {
 
             // We need extra image for the filter output - linear or optimal image
@@ -642,12 +648,20 @@ int32_t VkVideoDecoder::StartVideoSequence(VkParserDetectedVideoFormat* pVideoFo
         VulkanVideoFrameBuffer::ImageSpec& imageSpecFilter = imageSpecs[filterOutImageSpecsIndex];
         imageSpecFilter.createInfo = imageSpecDpb.createInfo;
         imageSpecFilter.createInfo.format = outImageFormat;
-        imageSpecFilter.createInfo.arrayLayers = 1;
+#if (_TRANSCODING)
+        if (m_numResizes > 0) {
+            imageSpecFilter.createInfo.arrayLayers = m_numResizes;
+            imageSpecFilter.createInfo.flags |= VK_IMAGE_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR;
+        }
+#endif
 
         if (m_enableDecodeComputeFilter == VK_TRUE) {
 
             // This is the image for the compute filter output: VK_IMAGE_USAGE_STORAGE_BIT
             imageSpecFilter.createInfo.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+#if (_TRANSCODING)
+            imageSpecFilter.createInfo.usage |= VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR;
+#endif
 
         } else if (m_useTransferOperation == VK_TRUE) {
 
@@ -1340,6 +1354,9 @@ int VkVideoDecoder::DecodePictureWithParameters(VkParserPerFrameDecodeParameters
     VkFence frameCompleteFence = frameSynchronizationInfo.frameCompleteFence;
     VkSemaphore videoDecodeCompleteSemaphore = frameSynchronizationInfo.frameCompleteSemaphore;
     VkSemaphore  consumerCompleteSemaphore = frameSynchronizationInfo.consumerCompleteSemaphore;
+#if (_TRANSCODING)
+    VkSemaphore* frameResizeSemaphores =  frameSynchronizationInfo.frameResizeSemaphore;
+#endif
     VkFence videoDecodeCompleteFence = frameCompleteFence;
 
     VkCommandBufferBeginInfo beginInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
@@ -1757,8 +1774,12 @@ int VkVideoDecoder::DecodePictureWithParameters(VkParserPerFrameDecodeParameters
                                                   &decodeToFilterSemaphore,
                                                   &binarySemaphoreValue,
                                                   &waitDecoderStageMasks,
+#if (_TRANSCODING)
+                                                  std::max(1, m_numResizes), m_numResizes > 0 ? frameResizeSemaphores : &videoDecodeCompleteSemaphore,
+#else
                                                   1, // signalSemaphoreCount
                                                   &videoDecodeCompleteSemaphore,
+#endif // _TRANSCODING
                                                   &computeCompleteTimelineValue,
                                                   &signalComputeStageMasks,
                                                   frameCompleteFence);

--- a/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.h
+++ b/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.h
@@ -353,4 +353,9 @@ private:
     VkSharedBaseObj<VulkanFilter> m_yuvFilter;
     VkSamplerYcbcrConversion m_dpbYcbcrConversion{VK_NULL_HANDLE};
     VkSamplerYcbcrConversion m_filterOutYcbcrConversion{VK_NULL_HANDLE};
+#if (_TRANSCODING)
+public:
+    int m_numResizes = 0;
+    std::vector<VulkanFilterYuvCompute::Rectangle> m_resizeResolution;
+#endif // _TRANSCODING
 };

--- a/vk_video_decoder/libs/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.cpp
+++ b/vk_video_decoder/libs/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.cpp
@@ -150,6 +150,9 @@ public:
 
     VkParserDecodePictureInfo m_picDispInfo;
     VkFence m_frameCompleteFence;
+#if (_TRANSCODING)
+    VkSemaphore m_frameResizeSemaphore[16];
+#endif //_TRANSCODING
     VkFence m_frameConsumerDoneFence;
     uint64_t m_frameCompleteTimelineValue;
     uint64_t m_frameConsumerDoneTimelineValue;
@@ -500,6 +503,11 @@ public:
 
                 m_perFrameDecodeImageSet[picId].m_hasFrameCompleteSignalSemaphore = true;
             }
+#if (_TRANSCODING)
+            for (int i = 0; i < 16; i++) {
+                pFrameSynchronizationInfo->frameResizeSemaphore[i] = m_perFrameDecodeImageSet[picId].m_frameResizeSemaphore[i];
+            }
+#endif //_TRANSCODING
         }
 
         if (m_perFrameDecodeImageSet[picId].m_useConsummerSignalSemaphore) {
@@ -584,6 +592,11 @@ public:
                 pDecodedFrame->frameCompleteSemaphore = m_perFrameDecodeImageSet.m_frameCompleteSemaphore;
                 pDecodedFrame->frameCompleteDoneSemValue = m_perFrameDecodeImageSet[pictureIndex].m_frameCompleteTimelineValue;
                 m_perFrameDecodeImageSet[pictureIndex].m_hasFrameCompleteSignalSemaphore = false;
+#if (_TRANSCODING)
+                for (int i = 0; i < 16; i++) {
+                    pDecodedFrame->frameResizeSemaphore[i] = m_perFrameDecodeImageSet[pictureIndex].m_frameResizeSemaphore[i];
+                }
+#endif //_TRANSCODING
 
                 pDecodedFrame->consumerCompleteSemaphore = m_perFrameDecodeImageSet.m_consumerCompleteSemaphore;
                 pDecodedFrame->frameConsumerDoneSemValue = DecodeFrameBufferIf::GetSemaphoreValue(
@@ -907,10 +920,8 @@ VkResult NvPerFrameDecodeResources::CreateImage( const VulkanDeviceContext* vkDe
         if (!imageViewArrayParent) {
 
             uint32_t baseArrayLayer = imageArrayParent ? imageIndex : 0;
-            VkImageSubresourceRange subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, baseArrayLayer, 1 };
+            VkImageSubresourceRange subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, baseArrayLayer, pImageSpec->createInfo.arrayLayers };
             if (pImageSpec->ycbcrConversion != VK_NULL_HANDLE) {
-                // Pass storage usage as planeUsageOverride so per-plane storage
-                // views are created alongside the combined sampled view.
                 VkImageUsageFlags planeUsage =
                     (pImageSpec->createInfo.usage & VK_IMAGE_USAGE_STORAGE_BIT)
                         ? VK_IMAGE_USAGE_STORAGE_BIT : 0;
@@ -935,7 +946,7 @@ VkResult NvPerFrameDecodeResources::CreateImage( const VulkanDeviceContext* vkDe
 
             m_imageViewState[pImageSpec->imageTypeIdx].view = imageViewArrayParent;
 
-            VkImageSubresourceRange subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, imageIndex, 1 };
+            VkImageSubresourceRange subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, imageIndex, pImageSpec->createInfo.arrayLayers };
             result = VkImageResourceView::Create(vkDevCtx, imageResource,
                                                  subresourceRange,
                                                  m_imageViewState[pImageSpec->imageTypeIdx].singleLevelView);
@@ -961,6 +972,13 @@ VkResult NvPerFrameDecodeResources::init(const VulkanDeviceContext* vkDevCtx)
     const VkFenceCreateInfo fenceInfo = { VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr };
     result = vkDevCtx->CreateFence(*vkDevCtx, &fenceInfo, nullptr, &m_frameConsumerDoneFence);
     assert(result == VK_SUCCESS);
+#if (_TRANSCODING)
+    const VkSemaphoreCreateInfo semInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO, nullptr };
+    for (int i = 0; i < 16; i++) {
+        result = vkDevCtx->CreateSemaphore(*vkDevCtx, &semInfo, nullptr, &m_frameResizeSemaphore[i]);
+        assert(result == VK_SUCCESS);
+    }
+#endif //_TRANSCODING
 
     Reset();
 
@@ -991,6 +1009,12 @@ void NvPerFrameDecodeResources::Deinit(const VulkanDeviceContext* vkDevCtx)
         m_frameConsumerDoneFence = VkFence();
     }
 
+#if (_TRANSCODING)
+        for (int i = 0; i < 16; i++) {
+            vkDevCtx->DestroySemaphore(*vkDevCtx, m_frameResizeSemaphore[i], nullptr);
+            m_frameResizeSemaphore[i] = VkSemaphore();
+        }
+#endif //_TRANSCODING
     for (uint32_t imageTypeIdx = 0; imageTypeIdx < DecodeFrameBufferIf::MAX_PER_FRAME_IMAGE_TYPES; imageTypeIdx++) {
 
         m_imageViewState[imageTypeIdx].view = nullptr;

--- a/vk_video_decoder/libs/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.h
+++ b/vk_video_decoder/libs/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.h
@@ -66,6 +66,9 @@ public:
     struct FrameSynchronizationInfo {
         VkFence frameCompleteFence;
         VkSemaphore frameCompleteSemaphore;
+#if (_TRANSCODING)
+        VkSemaphore frameResizeSemaphore[16];
+#endif //_TRANSCODING
         VkSemaphore consumerCompleteSemaphore;
         uint64_t frameConsumerDoneTimelineValue;
         uint64_t decodeCompleteTimelineValue;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -182,6 +182,14 @@ static void printHelp(VkVideoCodecOperationFlagBitsKHR codec)
                                         will run to completion. This will be followed by a full\n\
                                         intra-refresh cycle. This results in a fully intra-refreshed frame\n\
                                         being available after every `intraRefreshCycleDuration + index` frames.\n");
+#if (_TRANSCODING)
+    fprintf(stderr,
+    "--preset                        <integer> : [1, 4] corresponds to p1..p4 \n\
+    --profile                       <integer> : 0 - low latency streaming, 1 - archiving, 2 - svc \n\
+    --bitrate                       <integer> : Target bitrate of the encoded file in Mbps (Megabit per second)\n\
+    --vbvbuf-ratio                  <integer> : [1, 4] multiplier to vbv buffer size: CBR's vbvbuf = bitrate/framerate * vbvbuf-ratio, VBR's vbvbuf = bitrate * vbvbuf-ratio\n\
+    --numberResizedOutputs           <integer> followed by <integer>x<integer> : Number N of resized outputs to encode, followed by N resolution in format WidthxHeight\n");
+#endif //_TRANSCODING
 
 #ifdef NV_AQ_GPU_LIB_SUPPORTED
     fprintf(stderr, "\
@@ -466,6 +474,81 @@ int EncoderConfig::ParseArguments(int argc, const char *argv[])
             if (verbose) {
                 printf("Selected gopFrameCount: %d\n", gopFrameCount);
             }
+#if (_TRANSCODING)
+        } else if (strcmp(argv[i], "--profile") == 0) {
+            if ((++i >= argc) !=1) {
+                int encodeProfileVal;
+                int sscanf_result = sscanf(argv[i], "%d", &encodeProfileVal);
+                if (sscanf_result != 1 || encodeProfileVal < 0 || encodeProfileVal > 2) {
+                    fprintf(stderr, "invalid parameter for %s\n", argv[i - 1]);
+                    return -1;
+                } else {
+                    encodingProfile = static_cast<EncoderConfig::ENCODING_PROFILE>(encodeProfileVal);
+                }
+            }
+        } else if (strcmp(argv[i], "--preset") == 0) {
+            if ((++i >= argc) !=1) {
+                int pn;
+                int sscanf_result = sscanf(argv[i], "%d", &pn);
+                if (sscanf_result != 1 || pn < 1) {
+                    fprintf(stderr, "invalid parameter for %s\n", argv[i - 1]);
+                    return -1;
+                } else {
+                    qualityLevel = std::min(pn, 4) - 1;
+                }
+            }
+        } else if (strcmp(argv[i], "--bitrate") == 0) {
+            if ((++i >= argc) !=1) {
+            int targetBitrate;
+            int sscanf_result = sscanf(argv[i], "%d", &targetBitrate);
+            if (sscanf_result != 1 || targetBitrate <= 0 || targetBitrate >= 200) {
+                fprintf(stderr, "invalid parameter for %s\n", argv[i - 1]);
+                return -1;
+            }
+            averageBitrate = targetBitrate << 20;
+            }
+        } else if (strcmp(argv[i], "--vbvbuf-ratio") == 0) {
+            if ((++i >= argc) !=1) {
+                int vbvbuf_ratio;
+                int sscanf_result = sscanf(argv[i], "%d", &vbvbuf_ratio);
+                if (sscanf_result != 1 || vbvbuf_ratio <= 0 || vbvbuf_ratio > 8) {
+                    fprintf(stderr, "invalid parameter for %s\n", argv[i - 1]);
+                    return VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR;
+                }
+                vbvbufratio = vbvbuf_ratio;
+            }
+        } else if (strcmp(argv[i], "--numberResizedOutputs") == 0) {
+            if ((++i >= argc) !=1) {
+                int numResizedOutputs;
+                int sscanf_result = sscanf(argv[i], "%d", &numResizedOutputs);
+                if (sscanf_result != 1 || numResizedOutputs <= 0 || numResizedOutputs > 16) {
+                    fprintf(stderr, "invalid parameter for %s\n", argv[i - 1]);
+                    return VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR;
+                }
+                numEncoderResizedOutputs = numResizedOutputs;
+                std::cout << "numResizedOutputs " << numEncoderResizedOutputs << std::endl;
+                i++;
+                for (int n = 0; n < numResizedOutputs; n++)
+                {
+                    std::string resolutionStr { argv[i] };
+                    size_t x_pos = resolutionStr.find('x');
+                    if (x_pos != std::string::npos)
+                    {
+                        int resizedWidth = std::stoi(resolutionStr.substr(0, x_pos));
+                        int resizedHeight = std::stoi(resolutionStr.substr(x_pos + 1));
+                        if ((resizedWidth <= 0) || (resizedHeight <= 0)) {
+                            return VK_ERROR_INITIALIZATION_FAILED;
+                        }
+                        VulkanFilterYuvCompute::Rectangle resolutionRectangle;
+                        resolutionRectangle.width = resizedWidth;
+                        resolutionRectangle.height = resizedHeight;
+                        resizedOutputResolution.push_back(resolutionRectangle);
+                        std::cout << resizedWidth << " x " << resizedHeight << std::endl;
+                        i++;
+                    }
+                }
+            }
+#endif //_TRANSCODING
         } else if (args[i] == "--idrPeriod") {
             int32_t idrPeriod = EncoderConfig::DEFAULT_GOP_IDR_PERIOD;
             if (++i >= argc || !parseInt(args[i], idrPeriod)) {
@@ -824,6 +907,7 @@ int EncoderConfig::ParseArguments(int argc, const char *argv[])
         inputFileHandler.SetFrameGeometry(input.width, input.height, input.bpp, input.chromaSubsampling);
         // frameCount stays at the value from --numFrames (or default)
     } else {
+#if (!_TRANSCODING) // transcoding: the resolution will be read from the decoded video
         if (input.width == 0) {
             fprintf(stderr, "The input width must be specified\n");
             return -1;
@@ -833,6 +917,7 @@ int EncoderConfig::ParseArguments(int argc, const char *argv[])
             fprintf(stderr, "The input height must specified\n");
             return -1;
         }
+#endif // !_TRANSCODING
 
         inputFileHandler.SetFrameGeometry(input.width, input.height, input.bpp, input.chromaSubsampling);
 
@@ -858,10 +943,12 @@ int EncoderConfig::ParseArguments(int argc, const char *argv[])
                       <<  " should be different from zero and inferior to input file max frame count of "
                       << frameCount << ". Using input file frame count." << std::endl;
             numFrames = frameCount;
+#if (!_TRANSCODING) // For transcoding, frame count is determined during decoding
             if (numFrames == 0) {
                 fprintf(stderr, "No frames found in the input file, frame count is zero. Exit.");
                 return -1;
             }
+#endif // !_TRANSCODING
         }
     }
     // External frame input: numFrames comes from --numFrames arg (typically UINT32_MAX for streaming)
@@ -1021,8 +1108,10 @@ VkResult EncoderConfig::CreateCodecConfig(int argc, const char *argv[],
 
         VkResult result = vkEncoderConfigh264->InitializeParameters();
         if (result != VK_SUCCESS) {
+#if (!_TRANSCODING)
             assert(!"InitializeParameters failed");
             return result;
+#endif // !_TRANSCODING
         }
 
         encoderConfig = vkEncoderConfigh264;
@@ -1039,8 +1128,10 @@ VkResult EncoderConfig::CreateCodecConfig(int argc, const char *argv[],
 
         VkResult result = vkEncoderConfigh265->InitializeParameters();
         if (result != VK_SUCCESS) {
+#if (!_TRANSCODING)
             assert(!"InitializeParameters failed");
             return result;
+#endif // !_TRANSCODING
         }
 
         encoderConfig = vkEncoderConfigh265;
@@ -1057,8 +1148,10 @@ VkResult EncoderConfig::CreateCodecConfig(int argc, const char *argv[],
 
         VkResult result = vkEncoderConfigAV1->InitializeParameters();
         if (result != VK_SUCCESS) {
+#if (!_TRANSCODING)
             assert(!"InitializeParameters failed");
             return result;
+#endif //!_TRANSCODING
         }
 
         encoderConfig = vkEncoderConfigAV1;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -776,6 +776,10 @@ public:
     VkVideoEncodeUsageFlagsKHR encodeUsageHints;
     VkVideoEncodeContentFlagsKHR encodeContentHints;
     VkVideoEncodeTuningModeKHR tuningMode;
+#if (_TRANSCODING)
+    int numEncoderResizedOutputs;
+    std::vector<VulkanFilterYuvCompute::Rectangle> resizedOutputResolution;
+#endif // _TRANSCODING
     VkVideoCoreProfile videoCoreProfile;
     VkVideoCapabilitiesKHR videoCapabilities;
     VkVideoEncodeCapabilitiesKHR videoEncodeCapabilities;
@@ -836,6 +840,9 @@ public:
 
     EncoderInputFileHandler inputFileHandler;
     EncoderOutputFileHandler outputFileHandler;
+#if (_TRANSCODING)
+    EncoderOutputFileHandler resizedOutputFileHandler[16];
+#endif // _TRANSCODING
     EncoderQpMapFileHandler qpMapFileHandler;
 
     VulkanFilterYuvCompute::FilterType filterType;
@@ -880,6 +887,12 @@ public:
     int32_t  drmFormatModifierIndex; // -1 = disabled (OPTIMAL), >= 0 = index into non-linear modifier list
     uint64_t selectedDrmFormatModifier; // resolved modifier value (set during InitEncoder)
 
+#if (_TRANSCODING)
+    int vbvbufratio;
+    enum ENCODING_PROFILE { LOW_LATENCY_STREAMING = 0, ARCHIVING, SVC, ENUM_MAXVAL_NOTSET };
+    ENCODING_PROFILE encodingProfile;
+#endif // _TRANSCODING
+
     EncoderConfig()
     : appName()
     , deviceId(-1)
@@ -908,6 +921,9 @@ public:
     , encodeUsageHints(VK_VIDEO_ENCODE_USAGE_DEFAULT_KHR)
     , encodeContentHints(VK_VIDEO_ENCODE_CONTENT_DEFAULT_KHR)
     , tuningMode(VK_VIDEO_ENCODE_TUNING_MODE_DEFAULT_KHR)
+#if (_TRANSCODING)
+    , numEncoderResizedOutputs(0)
+#endif // _TRANSCODING
     , videoCoreProfile(codec, encodeChromaSubsampling, encodeBitDepthLuma, encodeBitDepthChroma)
     , videoCapabilities()
     , videoEncodeCapabilities()
@@ -989,6 +1005,10 @@ public:
     , crcOutputFileName()
     , drmFormatModifierIndex(-1)
     , selectedDrmFormatModifier(0)
+#if (_TRANSCODING)
+    , vbvbufratio(1)
+    , encodingProfile(ENUM_MAXVAL_NOTSET)
+#endif // _TRANSCODING
     { }
 
     virtual ~EncoderConfig() {}

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -517,6 +517,14 @@ int8_t EncoderConfigH264::InitDpbCount()
 {
     dpbCount = 0; // TODO: What is the need for this?
 
+#if (_TRANSCODING)
+    dpbCount = gopStructure.GetConsecutiveBFrameCount();
+    if (dpbCount == 0) {
+        dpbCount = 1;
+        return dpbCount + 1;
+    }
+#endif // _TRANSCODING
+
     uint8_t levelDpbSize = (uint8_t)(((1024 * levelLimits[levelIdc].maxDPB)) /
                             ((pic_width_in_mbs * pic_height_in_map_units) * 384));
 
@@ -570,6 +578,21 @@ bool EncoderConfigH264::InitRateControl()
     }
 
     // Use the level limit for the max VBV buffer size, and no more than 8 seconds at peak rate
+#if (_TRANSCODING)
+    double frameRate = ((frameRateNumerator > 0) && (frameRateDenominator > 0))
+                           ? (double)frameRateNumerator / frameRateDenominator
+                           : (double)FRAME_RATE_NUM_DEFAULT / (double)FRAME_RATE_DEN_DEFAULT;
+
+
+    if (encodingProfile == EncoderConfig::LOW_LATENCY_STREAMING)
+    {
+        vbvBufferSize = (uint32_t)(averageBitrate / frameRate * vbvbufratio); // averageBitrate is a uint32_t, no overflow
+    }
+    else if (encodingProfile == EncoderConfig::ARCHIVING)
+    {
+        vbvBufferSize = averageBitrate * vbvbufratio;
+    } else // Tymur: temporarily disable the following feature if encodingProfile is specified (the above code will be used instead)
+#endif // _TRANSCODING
     if (vbvBufferSize == 0) {
         vbvBufferSize = std::min(levelLimits[levelIdc].maxCPB * 1000, 120000000U);
         if (rateControlMode != VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR)

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -1072,6 +1072,96 @@ VkResult VkVideoEncoder::SubmitStagedInputFrame(VkSharedBaseObj<VkVideoEncodeFra
     return result;
 }
 
+#if (_TRANSCODING)
+VkResult VkVideoEncoder::LoadNextFrameDecoded(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo,
+                                              VulkanDecodedFrame* vkLastFrameDecoded, int decodedImgLayerIdx)
+{
+    encodeFrameInfo->frameInputOrderNum = m_inputFrameNum++;
+    encodeFrameInfo->lastFrame = !(encodeFrameInfo->frameInputOrderNum < (m_encoderConfig->numFrames - 1));
+    encodeFrameInfo->currImgLayerIdx = decodedImgLayerIdx;
+
+    if ((m_encoderConfig->enableQpMap == VK_TRUE) && m_encoderConfig->qpMapFileHandler.HandleIsValid()) {
+
+        VkResult result = LoadNextQpMapFrameFromFile(encodeFrameInfo);
+        if (result != VK_SUCCESS) {
+            return result;
+        }
+    }
+
+    {
+        // On success, stage the input frame for the encoder video input
+        StageInputFrameDecoded(encodeFrameInfo, vkLastFrameDecoded);
+        return VK_SUCCESS;
+    }
+
+    return VK_ERROR_INITIALIZATION_FAILED;
+}
+
+VkResult VkVideoEncoder::StageInputFrameDecoded(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo, VulkanDecodedFrame* vkLastFrameDecoded)
+{
+    assert(encodeFrameInfo);
+
+    VkResult result;
+    if (0) {//(m_inputComputeFilter != nullptr) || (m_encoderConfig->enableQpMap)) {
+        // Begin command buffer
+        VkCommandBufferBeginInfo beginInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr };
+        beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        VkCommandBuffer cmdBuf = encodeFrameInfo->inputCmdBuffer->BeginCommandBufferRecording(beginInfo);
+
+        if (m_inputComputeFilter != nullptr) {
+
+            VkSharedBaseObj<VkImageResourceView> linearInputImageView;
+            encodeFrameInfo->srcStagingImageView->GetImageView(linearInputImageView);
+
+            VkSharedBaseObj<VkImageResourceView> srcEncodeImageView;
+            encodeFrameInfo->srcEncodeImageResource->GetImageView(srcEncodeImageView);
+
+            result = m_inputComputeFilter->RecordCommandBuffer(cmdBuf,
+                                                            encodeFrameInfo->inputCmdBuffer->GetNodePoolIndex(),
+                                                            linearInputImageView.get(),
+                                                            encodeFrameInfo->srcStagingImageView->GetPictureResourceInfo(),
+                                                            srcEncodeImageView.get(),
+                                                            encodeFrameInfo->srcEncodeImageResource->GetPictureResourceInfo());
+            if (result != VK_SUCCESS) {
+                return result;
+            }
+        }
+            // Stage QPMap if it needs staging. Reuse the same command buffer used for staging of the input image
+        if (m_encoderConfig->enableQpMap && (m_qpMapTiling != VK_IMAGE_TILING_LINEAR)) {
+            result = StageInputFrameQpMap(encodeFrameInfo, cmdBuf);
+            if (result != VK_SUCCESS) {
+                return result;
+            }
+        }
+        result = encodeFrameInfo->inputCmdBuffer->EndCommandBufferRecording(cmdBuf);
+        // Now submit the staged input to the queue
+        SubmitStagedInputFrame(encodeFrameInfo);
+    }
+
+
+    if (encodeFrameInfo->srcEncodeImageResource == nullptr) {
+        bool success = m_inputImagePool->GetAvailableImage(encodeFrameInfo->srcEncodeImageResource,
+                                                                 VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR);
+        assert(success);
+        assert(encodeFrameInfo->srcEncodeImageResource != nullptr);
+    }
+    encodeFrameInfo->setLastDecodedFrame(vkLastFrameDecoded);
+
+    // and encode the input frame with the encoder next
+    auto timeStart = std::chrono::steady_clock::now();
+    EncodeFrameCommon(encodeFrameInfo);
+    auto timeEnd = std::chrono::steady_clock::now();
+    m_encodeTimeMicroSec += std::chrono::duration_cast<std::chrono::microseconds>(timeEnd - timeStart).count();
+
+    return VK_SUCCESS;
+}
+
+VkResult VkVideoEncoder::SubmitStagedInputFrameDecoded(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo, VulkanDecodedFrame& vkLastFrameDecoded)
+{
+    return VK_SUCCESS; // not used
+}
+#endif //_TRANSCODING
+
 VkResult VkVideoEncoder::AssembleBitstreamData(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo,
                                                uint32_t frameIdx, uint32_t ofTotalFrames)
 {
@@ -1085,7 +1175,11 @@ VkResult VkVideoEncoder::AssembleBitstreamData(VkSharedBaseObj<VkVideoEncodeFram
 
     if(encodeFrameInfo->bitstreamHeaderBufferSize > 0) {
         size_t nonVcl = WriteDataToFile(encodeFrameInfo->bitstreamHeaderBuffer + encodeFrameInfo->bitstreamHeaderOffset,
-                                              encodeFrameInfo->bitstreamHeaderBufferSize);
+                                              encodeFrameInfo->bitstreamHeaderBufferSize
+#if (_TRANSCODING)
+                                              , encodeFrameInfo->currImgLayerIdx
+#endif // _TRANSCODING
+                                              );
 
         if (m_encoderConfig->verboseFrameStruct) {
             std::cout << "       == Non-Vcl data " << (nonVcl ? "SUCCESS" : "FAIL")
@@ -1144,7 +1238,11 @@ VkResult VkVideoEncoder::AssembleBitstreamData(VkSharedBaseObj<VkVideoEncodeFram
     while (totalBytesWritten < encodeResult.bitstreamSize) { // handle partial writes
         size_t remainingBytes = encodeResult.bitstreamSize - totalBytesWritten;
         size_t bytesWritten = WriteDataToFile(data + encodeResult.bitstreamStartOffset + totalBytesWritten,
-                                                    remainingBytes);
+                                                    remainingBytes
+#if (_TRANSCODING)
+                                                    , encodeFrameInfo->currImgLayerIdx
+#endif // _TRANSCODING
+                                                    );
         if (bytesWritten == 0) {
             std::cerr << "Error writing VCL data" << std::endl;
             return VK_ERROR_OUT_OF_HOST_MEMORY;
@@ -1222,7 +1320,11 @@ VkResult VkVideoEncoder::WriteBitstreamToFile(
     if (encodeFrameInfo->bitstreamHeaderBufferSize > 0) {
         WriteDataToFile(
             encodeFrameInfo->bitstreamHeaderBuffer + encodeFrameInfo->bitstreamHeaderOffset,
-            encodeFrameInfo->bitstreamHeaderBufferSize);
+            encodeFrameInfo->bitstreamHeaderBufferSize
+#if (_TRANSCODING)
+            , encodeFrameInfo->currImgLayerIdx
+#endif // _TRANSCODING
+            );
     }
 
     if (readback.readbackDone && readback.bitstreamSize > 0) {
@@ -1237,7 +1339,11 @@ VkResult VkVideoEncoder::WriteBitstreamToFile(
         size_t totalBytesWritten = 0;
         while (totalBytesWritten < readback.bitstreamSize) {
             size_t remaining = readback.bitstreamSize - totalBytesWritten;
-            size_t written = WriteDataToFile(src + totalBytesWritten, remaining);
+            size_t written = WriteDataToFile(src + totalBytesWritten, remaining
+#if (_TRANSCODING)
+                                             , encodeFrameInfo->currImgLayerIdx
+#endif // _TRANSCODING
+                                             );
             if (written == 0) {
                 fprintf(stderr, "[AsyncAssembly] Error writing VCL data\n");
                 return VK_ERROR_OUT_OF_HOST_MEMORY;
@@ -1484,7 +1590,13 @@ VkResult VkVideoEncoder::InitEncoder(VkSharedBaseObj<EncoderConfig>& encoderConf
         std::cout << std::endl;
 
         const uint64_t maxFramesToDump = std::min<uint32_t>(m_encoderConfig->numFrames, m_encoderConfig->gopStructure.GetGopFrameCount() + 19);
+
+#if (_TRANSCODING)
+    if (maxFramesToDump < 256)
+#endif // _TRANSCODING
+    {
         m_encoderConfig->gopStructure.PrintGopStructure(maxFramesToDump);
+    }
 
         if (m_encoderConfig->verboseFrameStruct) {
             m_encoderConfig->gopStructure.DumpFramesGopStructure(0, maxFramesToDump);
@@ -2435,6 +2547,15 @@ VkImageLayout VkVideoEncoder::TransitionImageLayout(VkCommandBuffer cmdBuf,
         imageBarrier.dstAccessMask = 0;
         imageBarrier.srcStageMask = VK_PIPELINE_STAGE_TRANSFER_BIT;
         imageBarrier.dstStageMask = VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR;
+#if (_TRANSCODING)
+    } else if ((oldLayout == VK_IMAGE_LAYOUT_VIDEO_DECODE_DPB_KHR) && (newLayout == VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR || newLayout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)) {
+        imageBarrier.srcAccessMask = VK_ACCESS_2_VIDEO_DECODE_WRITE_BIT_KHR;
+        imageBarrier.dstAccessMask = VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR;
+        imageBarrier.srcStageMask = VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR;
+        imageBarrier.dstStageMask = VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR;
+        imageBarrier.srcQueueFamilyIndex = (uint32_t)m_vkDevCtx->GetVideoDecodeQueueFamilyIdx();
+        imageBarrier.dstQueueFamilyIndex = (uint32_t)m_vkDevCtx->GetVideoEncodeQueueFamilyIdx();
+#endif // _TRANSCODING
     } else {
 #ifdef __cpp_exceptions
         throw std::invalid_argument("unsupported layout transition!");
@@ -2724,13 +2845,55 @@ VkResult VkVideoEncoder::RecordVideoCodingCmd(VkSharedBaseObj<VkVideoEncodeFrame
     encodeBeginInfo.videoSession = *encodeFrameInfo->videoSession;
     encodeBeginInfo.videoSessionParameters = *encodeFrameInfo->videoSessionParameters;
 
+    const VulkanDeviceContext* vkDevCtx = encodeCmdBuffer->GetDeviceContext();
+
+#if (_TRANSCODING)
+    VkSharedBaseObj<VkImageResourceView> srcEncodeImageView;
+    encodeFrameInfo->srcEncodeImageResource->GetImageView(srcEncodeImageView);
+    VkSharedBaseObj<VkImageResourceView> lastDecodedImageView;
+    // encodeFrameInfo->srcEncodeImageResource->GetImageView(lastDecodedImageView);
+    VulkanDecodedFrame* vkLast = encodeFrameInfo->getLastDecodedFrame();
+    bool getResourceView = vkLast->imageViews[VulkanDecodedFrame::IMAGE_VIEW_TYPE_OPTIMAL_DISPLAY].GetImageResourceView(lastDecodedImageView);
+    assert(getResourceView);
+    VkImageLayout srcImgNewLayout = TransitionImageLayout(cmdBuf, srcEncodeImageView, VK_IMAGE_LAYOUT_VIDEO_DECODE_DPB_KHR, VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR);
+    VkImageLayout linearImgNewLayout = TransitionImageLayout(cmdBuf, lastDecodedImageView, VK_IMAGE_LAYOUT_VIDEO_DECODE_DPB_KHR, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+    (void)srcImgNewLayout;
+    (void)linearImgNewLayout;
+    VkVideoPictureResourceInfoKHR* pSrcPictureResource = encodeFrameInfo->srcEncodeImageResource->GetPictureResourceInfo();
+
+    if (m_encoderConfig->numEncoderResizedOutputs > 0) {
+
+        VkSharedBaseObj<VkImageResource> imageResource = lastDecodedImageView->GetImageResource();
+        VkImageSubresourceRange subresourceRange{};
+        subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        subresourceRange.baseMipLevel = 0;
+        subresourceRange.levelCount = 1;
+        subresourceRange.baseArrayLayer = encodeFrameInfo->currImgLayerIdx; // Specify the desired view index
+        subresourceRange.layerCount = lastDecodedImageView->GetImageResource()->GetImageCreateInfo().arrayLayers;
+        VkResult result = VkImageResourceView::Create(vkDevCtx, imageResource, subresourceRange,
+                                                      encodeFrameInfo->m_ImageViewResource);
+        (void)result;
+        pSrcPictureResource->imageViewBinding = encodeFrameInfo->m_ImageViewResource->GetImageView();
+
+        encodeFrameInfo->setDecodeCompleteSemaphore(&vkLast->frameResizeSemaphore[encodeFrameInfo->currImgLayerIdx]);
+
+    } else {
+
+        pSrcPictureResource->imageViewBinding = lastDecodedImageView->GetImageView();
+
+        encodeFrameInfo->setDecodeCompleteSemaphore(&vkLast->frameCompleteSemaphore);
+
+    }
+    encodeFrameInfo->encodeInfo.srcPictureResource.imageViewBinding = pSrcPictureResource->imageViewBinding;
+#endif // _TRANSCODING
+
     assert((encodeFrameInfo->encodeInfo.referenceSlotCount) <= ARRAYSIZE(encodeFrameInfo->dpbImageResources));
     // TODO: Calculate the number of DPB slots for begin against the multiple frames.
     encodeBeginInfo.referenceSlotCount = encodeFrameInfo->encodeInfo.referenceSlotCount + 1;
 
     encodeBeginInfo.pReferenceSlots = encodeFrameInfo->referenceSlotsInfo;
 
-    const VulkanDeviceContext* vkDevCtx = encodeCmdBuffer->GetDeviceContext();
+    // const VulkanDeviceContext* vkDevCtx = encodeCmdBuffer->GetDeviceContext(); // moved before transcoding section
 
     // Handle the query indexes — querySlotId comes from the encode command
     // buffer pool node, set by GetQueryPool(). Unique per in-flight encode.
@@ -2877,6 +3040,7 @@ VkResult VkVideoEncoder::SubmitVideoCodingCmds(VkSharedBaseObj<VkVideoEncodeFram
         }
     } else
 #else // NV_AQ_GPU_LIB_SUPPORTED
+#if (!_TRANSCODING)
     if (encodeFrameInfo->inputCmdBuffer) {
         waitSemaphoreInfos[waitSemaphoreCount].sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO_KHR;
         waitSemaphoreInfos[waitSemaphoreCount].semaphore = encodeFrameInfo->inputCmdBuffer->GetSemaphore();
@@ -2886,6 +3050,17 @@ VkResult VkVideoEncoder::SubmitVideoCodingCmds(VkSharedBaseObj<VkVideoEncodeFram
         waitSemaphoreInfos[waitSemaphoreCount].deviceIndex = 0;
         waitSemaphoreCount++;
     }
+#else // _TRANSCODING
+    if (encodeFrameInfo->inputCmdBuffer == nullptr) {
+        waitSemaphoreInfos[waitSemaphoreCount].sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO_KHR;
+        waitSemaphoreInfos[waitSemaphoreCount].semaphore = *encodeFrameInfo->getDecodeCompleteSemaphore(); // transcoding: inputCmdBuff is nullptr
+        waitSemaphoreInfos[waitSemaphoreCount].value = 0; // Binary semaphore
+        // Use transfer bit since these semaphores come from transfer operations
+        waitSemaphoreInfos[waitSemaphoreCount].stageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR;
+        waitSemaphoreInfos[waitSemaphoreCount].deviceIndex = 0;
+        waitSemaphoreCount++;
+    }
+#endif // _TRANSCODING
 #endif // NV_AQ_GPU_LIB_SUPPORTED
     if (encodeFrameInfo->qpMapCmdBuffer) {
         waitSemaphoreInfos[waitSemaphoreCount].sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO_KHR;
@@ -3272,7 +3447,11 @@ void VkVideoEncoder::ConsumerThread()
    std::cout << "ConsumerThread is exiting now.\n" << std::endl;
 }
 
-size_t VkVideoEncoder::WriteDataToFile(const uint8_t* data, size_t size)
+size_t VkVideoEncoder::WriteDataToFile(const uint8_t* data, size_t size
+#if (_TRANSCODING)
+                                       , int imgLayerIdx
+#endif // _TRANSCODING
+                                       )
 {
     if (!data || size == 0) {
         return 0;
@@ -3281,7 +3460,14 @@ size_t VkVideoEncoder::WriteDataToFile(const uint8_t* data, size_t size)
     if (m_crc.Enabled()) {
         m_crc.UpdateCrc(data, size);
     }
-    size_t bytesWritten = fwrite(data, 1, size, m_encoderConfig->outputFileHandler.GetFileHandle());
+    size_t bytesWritten = fwrite(data, 1, size,
+#if (_TRANSCODING)
+        m_encoderConfig->numEncoderResizedOutputs == 0 ? m_encoderConfig->outputFileHandler.GetFileHandle() :
+            m_encoderConfig->resizedOutputFileHandler[imgLayerIdx].GetFileHandle()
+#else
+        m_encoderConfig->outputFileHandler.GetFileHandle()
+#endif // _TRANSCODING
+    );
     return bytesWritten;
 }
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
@@ -46,6 +46,9 @@
 #endif // NV_AQ_GPU_LIB_SUPPORTED
 #include "VkVideoEncoder/VkVideoEncoderPsnr.h"
 #include "VkCodecUtils/VkVideoCrc.h"
+#if (_TRANSCODING)
+#include "VkCodecUtils/VulkanDecodedFrame.h"
+#endif // _TRANSCODING
 
 class VkVideoEncoderH264;
 class VkVideoEncoderH265;
@@ -183,6 +186,11 @@ public:
             , qpMapCmdBuffer()
             , m_parent(nullptr)
             , m_parentIndex(-1)
+#if (_TRANSCODING)
+            , m_decodeCompeteSemaphore(nullptr)
+            , m_lastDecodedFrame{nullptr}
+            , currImgLayerIdx(0)
+#endif // _TRANSCODING
             , m_codec(codec)
         {
             assert(ARRAYSIZE(referenceSlotsInfo) == MAX_IMAGE_REF_RESOURCES);
@@ -265,12 +273,12 @@ public:
         // before accessing the external input image. Typically this is the
         // producer's graph timeline semaphore.
         std::vector<VkSemaphore>              inputWaitSemaphores;
-        std::vector<uint64_t>                 inputWaitSemaphoreValues;  // 0 for binary
-        std::vector<VkPipelineStageFlags2>    inputWaitDstStageMasks;
+        std::vector<uint64_t>                 inputWaitSemaphoreValues;
 
         // Signal semaphores: signaled when the staging copy is complete and the
         // external input image is no longer needed. Typically this is the
         // consumer's release timeline semaphore.
+        std::vector<VkPipelineStageFlags2>    inputWaitDstStageMasks;
         std::vector<VkSemaphore>              inputSignalSemaphores;
         std::vector<uint64_t>                 inputSignalSemaphoreValues;  // 0 for binary
 
@@ -283,6 +291,9 @@ public:
             inputSignalSemaphoreValues.clear();
         }
 
+#if (_TRANSCODING)
+        VkSharedBaseObj<VkImageResourceView>               m_ImageViewResource;
+#endif // _TRANSCODING
         VkResult SyncHostOnCmdBuffComplete() {
 
             if (inputCmdBuffer) {
@@ -463,10 +474,31 @@ public:
             m_parentIndex = -1;
             m_parent = nullptr;
         }
+#if (_TRANSCODING)
+    VkSemaphore* getDecodeCompleteSemaphore() const {
+        return m_decodeCompeteSemaphore;
+    }
+
+    void setDecodeCompleteSemaphore(VkSemaphore* inputSemaphore) {
+        m_decodeCompeteSemaphore = inputSemaphore;
+    }
+#endif // _TRANSCODING
 
     private:
         VkSharedBaseObj<VulkanBufferPoolIf>  m_parent;
         int32_t                             m_parentIndex;
+#if (_TRANSCODING)
+        VkSemaphore*                        m_decodeCompeteSemaphore;
+        VulkanDecodedFrame*                 m_lastDecodedFrame;
+    public:
+        int                                 currImgLayerIdx;
+        void setLastDecodedFrame(VulkanDecodedFrame* lastDecodedFrame) {
+            m_lastDecodedFrame = lastDecodedFrame;
+        }
+        VulkanDecodedFrame* getLastDecodedFrame() const {
+            return m_lastDecodedFrame;
+        }
+#endif // _TRANSCODING
         VkVideoCodecOperationFlagBitsKHR    m_codec;
     };
 #ifdef VIDEO_DISPLAY_QUEUE_SUPPORT
@@ -592,6 +624,9 @@ public:
         , m_linearQpMapImagePool()
         , m_qpMapImagePool()
         , m_psnr()
+#if (_TRANSCODING)
+        , m_encodeTimeMicroSec(0)
+#endif  //_TRANSCODING
     { }
 
     // Factory Function
@@ -668,6 +703,12 @@ public:
     VkResult StageInputFrameQpMap(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo,
                                   VkCommandBuffer cmdBuf = VK_NULL_HANDLE);
     VkResult SubmitStagedInputFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
+#if (_TRANSCODING)
+    VkResult LoadNextFrameDecoded(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo,
+                                  VulkanDecodedFrame* vkLastFrameDecoded, int decodedImgLayerIdx);
+    VkResult StageInputFrameDecoded(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo, VulkanDecodedFrame* vkLastFrameDecoded);
+    VkResult SubmitStagedInputFrameDecoded(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo, VulkanDecodedFrame& vkLastFrameDecoded);
+#endif // _TRANSCODING
     VkResult SubmitStagedQpMap(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
     VkResult EncodeFrameCommon(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
     virtual VkResult EncodeFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo) = 0; // Must be implemented by the codec
@@ -701,7 +742,11 @@ public:
                                            uint32_t frameIdx, uint32_t ofTotalFrames);
 
     
+#if (_TRANSCODING)
+    size_t WriteDataToFile(const uint8_t* data, size_t size, int imgLayerIdx = 0);
+#else
     size_t WriteDataToFile(const uint8_t* data, size_t size);
+#endif
     virtual VkResult ReadbackBitstreamData(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo,
                                            BitstreamReadback& readback);
 
@@ -975,6 +1020,13 @@ protected:
     std::mutex                               m_assemblyFileMutex;
     std::condition_variable                  m_assemblyOrderCV;
     std::atomic<uint32_t>                    m_assemblyErrorCount{0};
+#if (_TRANSCODING)
+    uint64_t                                 m_encodeTimeMicroSec;
+public:
+    uint64_t getFps() const {
+        return m_inputFrameNum * 1000000 / m_encodeTimeMicroSec;
+    }
+#endif // _TRANSCODING
 };
 
 VkResult CreateVideoEncoderH264(const VulkanDeviceContext* vkDevCtx,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.cpp
@@ -17,7 +17,7 @@
 #include "VkVideoGopStructure.h"
 #include <limits>
 
-VkVideoGopStructure::VkVideoGopStructure(uint8_t gopFrameCount,
+VkVideoGopStructure::VkVideoGopStructure(uint16_t gopFrameCount,
                                          int32_t idrPeriod,
                                          uint8_t consecutiveBFrameCount,
                                          uint8_t temporalLayerCount,
@@ -43,6 +43,10 @@ VkVideoGopStructure::VkVideoGopStructure(uint8_t gopFrameCount,
 bool VkVideoGopStructure::Init(uint64_t maxNumFrames)
 {
     m_gopFrameCycle = (uint8_t)(m_consecutiveBFrameCount + 1);
+    m_gopFrameCount = (uint32_t)std::min<uint64_t>(m_gopFrameCount, maxNumFrames);
+    if (m_idrPeriod > 0) {
+        m_idrPeriod = (uint32_t)std::min<uint64_t>(m_idrPeriod, maxNumFrames);
+    }
     return true;
 }
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.h
@@ -27,7 +27,7 @@
 #include <iomanip>
 #include <algorithm>  // for std::min
 
-static const uint32_t MAX_GOP_SIZE = 64;
+static const uint32_t MAX_GOP_SIZE = UINT16_MAX;
 
 class VkVideoGopStructure {
 
@@ -81,7 +81,7 @@ public:
         {}
     };
 
-    VkVideoGopStructure(uint8_t gopFrameCount = 8,
+    VkVideoGopStructure(uint16_t gopFrameCount = 8,
                         int32_t idrPeriod = 60,
                         uint8_t consecutiveBFrameCount = 2,
                         uint8_t temporalLayerCount = 1,

--- a/vk_video_transcoder/BUILD.md
+++ b/vk_video_transcoder/BUILD.md
@@ -1,0 +1,216 @@
+# Build Instructions
+
+Instructions for building this repository on Linux, Windows, L4.
+
+## Index
+
+1. [Repository Set-Up](#repository-set-up)
+2. [Windows Build](#building-on-windows)
+3. [Linux Build](#building-on-linux)
+4. [Linux for Tegra Build](#building-on-linux-for-tegra)
+5. [Android Build](#building-on-android)
+
+## Contributing to the Repository
+
+If you intend to contribute, the preferred work flow is for you to develop
+your contribution in a fork of this repository in your GitHub account and
+then submit a pull request.
+Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file in this repository for more details.
+
+## Repository Set-Up
+
+  Please make sure you have installed the latest NVIDIA BETA drivers from https://developer.nvidia.com/vulkan-driver.
+  The minimum supported BETA driver versions by this application are 527.86 (Windows) / 525.47.04 (Linux) that
+  must support Vulkan API version 1.3.230 or later.
+  The Windows and Linux BETA drivers are available for download at https://developer.nvidia.com/vulkan-beta-51769-windows
+  and https://developer.nvidia.com/vulkan-beta-5154924-linux, respectively.
+
+### Download the Repository
+
+   Vulkan Video Test application Gerrit repository:
+   VULKAN_VIDEO_GIT_REPO="https://github.com/nvpro-samples/vk_video_samples.git"
+
+   $ git clone $VULKAN_VIDEO_GIT_REPO
+
+   APP_INSTALLED_LOC=$(pwd)/"vk_video_samples/vk_video_transcoder"
+
+## Building On Windows
+
+### Windows Build Requirements
+
+Windows 10 or Windows 11 with the following software packages:
+
+- Microsoft Visual Studio VS2017 or later (any version).
+- [CMake](http://www.cmake.org/download/)
+  - Tell the installer to "Add CMake to the system PATH" environment variable.
+- [Python 3](https://www.python.org/downloads)
+  - Select to install the optional sub-package to add Python to the system PATH
+    environment variable.
+  - Ensure the `pip` module is installed (it should be by default)
+  - Python3.3 or later is necessary for the Windows py.exe launcher that is used to select python3
+  rather than python2 if both are installed
+- [Git](http://git-scm.com/download/win)
+  - Tell the installer to allow it to be used for "Developer Prompt" as well as "Git Bash".
+  - Tell the installer to treat line endings "as is" (i.e. both DOS and Unix-style line endings).
+  - Install both the 32-bit and 64-bit versions, as the 64-bit installer does not install the
+    32-bit libraries and tools.
+- [Vulkan SDK](https://vulkan.lunarg.com)
+  - install current Vulkan SDK (i.e. VulkanSDK-1.3.*-Installer.exe) from https://vulkan.lunarg.com/
+- [FFMPEG libraries for Windows]
+    Download the latest version of the FFMPEG shared libraries archive from https://github.com/BtbN/FFmpeg-Builds/releases.
+    The archive must have the following pattern in the name ffmpeg-*-win64-*-shared.zip
+    For example:
+    https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl-shared.zip
+    Then extract the archive to <APP_INSTALLED_LOC>\bin\libs\ffmpeg and add the path of the <APP_INSTALLED_LOC>\bin\libs\ffmpeg\win64\ of
+    the application. Please make sure that <APP_INSTALLED_LOC>\bin\libs\ffmpeg\win64\bin location contains
+    avformat-59.dll, avutil-59.dll and avcodec-59.dll shared libraries and <APP_INSTALLED_LOC>\bin\libs\ffmpeg\win64\lib contains the
+    corresponding lib files.
+- Notes for using [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
+  - Vulkan Video currently does not support [Windows Subsystem for Linux].
+
+### Windows Build - Microsoft Visual Studio
+
+1. Open a Developer Command Prompt for VS201x
+2. Change directory to `<APP_INSTALLED_LOC>/../vk_video_decoder` -- the decoder folder in the cloned git repository
+3. Run `update_external_sources.bat` -- this will download and build external components
+4. Change directory to `<APP_INSTALLED_LOC>` -- the vk_video_transcoder folder in the cloned git repository
+5. Create a `build` directory, change into that directory, and run cmake and build as follows:
+
+### Windows Build for debug - using shell
+
+        cmake .. -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_INSTALL_PREFIX="$(pwd)/install/Debug" -DCMAKE_BUILD_TYPE=Debug
+        cmake --build . --parallel 16 --config Debug
+        cmake --build . --config Debug --target INSTALL
+
+### Windows Build for release - using shell
+
+        cmake .. -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_INSTALL_PREFIX="$(pwd)/install/Release" -DCMAKE_BUILD_TYPE=Release
+        cmake --build . --parallel 16 --config Release
+        cmake --build . --config Release --target INSTALL
+
+### Windows Notes
+
+#### The Vulkan Loader Library
+
+Vulkan programs must be able to find and use the vulkan-1.dll library.
+While several of the test and demo projects in the Windows solution set this up automatically, doing so manually may be necessary for custom projects or solutions.
+Make sure the library is either installed in the C:\Windows\System folder, or that the PATH environment variable includes the folder where the library resides.
+
+## Building On Linux
+
+### Linux Build Requirements
+
+This repository has been built and tested on the two most recent Ubuntu LTS versions with
+Vulkan SDK vulkansdk-linux-x86_64-1.2.189.0.tar.gz from https://vulkan.lunarg.com/sdk/home#linux.
+Currently, the oldest supported version is Ubuntu 18.04.5 LTS, meaning that the minimum supported
+compiler versions are GCC 7.5.0 and Clang 6.0.0, although earlier versions may work.
+It should be straightforward to adapt this repository to other Linux distributions.
+
+**Required Package List:**
+
+1. sudo apt-get install git cmake build-essential libx11-xcb-dev libxkbcommon-dev libmirclient-dev libwayland-dev libxrandr-dev libavcodec-dev libavformat-dev libavutil-dev ninja-build
+
+### Linux Vulkan Video Transcoder Demo Build
+
+2. In a Linux terminal, `cd <APP_INSTALLED_LOC>/vk_video_decoder` -- the root of the cloned git repository
+        cd $APP_INSTALLED_LOC
+3. Execute `./update_external_sources.sh` -- this will download and build external components
+        $ ./update_external_sources.sh
+4. Create a `build` directory, change into that directory:
+
+        mkdir build
+        cd build
+
+5. Run cmake to configure the build:
+
+        `cd <APP_INSTALLED_LOC>/vk_video_transcoder`
+
+        # Transcoder build configuration (please select Debug or Release build type):
+        For example, for Debug build:
+        cmake -DCMAKE_BUILD_TYPE=Debug ..
+
+        OR for Debug build:
+        cmake -DCMAKE_BUILD_TYPE=Release ..
+
+6. Run `make -j16` to build the sample application.
+
+7. Usage example:
+
+        `./demos/vk-video-dec-test -i inputfile.mkv --codec hevc --profile 0 --bitrate 5 --preset 1 --vbvbuf-ratio 2`
+        * `profile 0` - only p-frames, `profile 1` - 3 b-frames, `bitrate` is a target bitrate in MB/s, please see `--help` for more information
+
+### WSI Support Build Options
+
+By default, the Vulkan video demo is built with support for all 3 Vulkan-defined WSI display servers: Xcb, Xlib and Wayland, as well as direct-to-display.
+It is recommended to build the repository components with support for these display servers to maximize their usability across Linux platforms.
+If it is necessary to build these modules without support for one of the display servers, the appropriate CMake option of the form `BUILD_WSI_xxx_SUPPORT` can be set to `OFF`.
+See the top-level CMakeLists.txt file for more info.
+
+### Linux Decoder Tests
+
+Before you begin, check if your driver has Vulkan Video extensions enabled:
+
+        $ vulkaninfo | grep VK_KHR_video
+
+The output should be:
+           VK_KHR_video_decode_queue : extension revision 1
+           VK_KHR_video_encode_queue : extension revision 1
+           VK_KHR_video_queue : extension revision 1
+
+To run the Vulkan Video Decode sample from the build dir (for Windows change to build\install\Debug\bin\ or build\install\Release\bin\):
+
+        $ ./demos/vk-video-dec-test -i '<Video content file with h.264 or h.265 format>'
+        # -- Optional parameter is the max number of frames to be displayed with --c N.
+        # For example if the max frames required are 100, then:
+        $ ./demos/vk-video-dec-test -i /data/nvidia-l4t/video-samples/Palm_Trees_4Videvo.mov --c 100
+        # One can find some sample videos in h.264 and h.265 formats here:
+        # http://jell.yfish.us/
+
+You can select which WSI subsystem is used to build the demos using a CMake option
+called DEMOS_WSI_SELECTION.
+Supported options are XCB (default), XLIB, WAYLAND, and MIR.
+Note that you must build using the corresponding BUILD_WSI_*_SUPPORT enabled at the
+base repository level (all SUPPORT options are ON by default).
+For instance, creating a build that will use Xlib to build the demos,
+your CMake command line might look like:
+
+    cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DDEMOS_WSI_SELECTION=XLIB
+
+## Building On Linux for Tegra
+
+### Linux for Tegra Build Requirements
+
+This repository has been built and tested on the two most recent Ubuntu LTS versions.
+Currently, the oldest supported version is Ubuntu 18.04.5 LTS, meaning that the minimum supported compiler versions are GCC 7.5.0 and Clang 6.0.0, although earlier versions may work.
+It should be straightforward to adapt this repository to other Linux distributions.
+
+**Required Package List:**
+
+    sudo apt-get install git cmake build-essential libx11-xcb-dev libxkbcommon-dev libmirclient-dev libwayland-dev libxrandr-dev libavcodec-dev libavformat-dev libavutil-dev
+
+### Linux for Tegra Vulkan Video Demo Build
+
+1. Set the TEGRA_TOP environment variables to the location of the application
+        export TEGRA_TOP=$APP_INSTALLED_LOC
+
+2. Follow the Linux Build instructions above
+
+## Ninja Builds - All Platforms
+
+The [Qt Creator IDE](https://qt.io/download-open-source/#section-2) can open a root CMakeList.txt
+as a project directly, and it provides tools within Creator to configure and generate Vulkan SDK
+build files for one to many targets concurrently.
+Alternatively, when invoking CMake, use the `-G "Codeblocks - Ninja"` option to generate Ninja build
+files to be used as project files for QtCreator
+
+- Follow the steps defined elsewhere for the OS using the update\_external\_sources script or as
+  shown in **Loader and Validation Layer Dependencies** below
+- Open, configure, and build the glslang CMakeList.txt files. Note that building the glslang
+  project will provide access to spirv-tools and spirv-headers
+- Then do the same with the Vulkan-LoaderAndValidationLayers CMakeList.txt file
+- In order to debug with QtCreator, a
+  [Microsoft WDK: eg WDK 10](http://go.microsoft.com/fwlink/p/?LinkId=526733) is required.
+
+Note that installing the WDK breaks the MSVC vcvarsall.bat build scripts provided by MSVC,
+requiring that the LIB, INCLUDE, and PATHenv variables be set to the WDK paths by some other means
+

--- a/vk_video_transcoder/CMakeLists.txt
+++ b/vk_video_transcoder/CMakeLists.txt
@@ -1,0 +1,2 @@
+set (_TRANSCODING 1)
+add_subdirectory("../vk_video_decoder" ${CMAKE_CURRENT_BINARY_DIR})

--- a/vk_video_transcoder/demos/CMakeLists.txt
+++ b/vk_video_transcoder/demos/CMakeLists.txt
@@ -1,0 +1,68 @@
+set(CMAKE_WARN_DEPRECATED OFF)
+
+set(DEMO_INCLUDE_DIRS
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}/..
+)
+
+file(GLOB TEXTURES
+  "${PROJECT_SOURCE_DIR}/demos/*.ppm"
+  )
+file(COPY ${TEXTURES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+if(WIN32)
+  set (LIBRARIES "${API_LOWERCASE}-${MAJOR}")
+elseif(UNIX)
+  set (LIBRARIES "${API_LOWERCASE}")
+else()
+endif()
+
+if(WIN32)
+    # For Windows, since 32-bit and 64-bit items can co-exist, we build each in its own build directory.
+    # 32-bit target data goes in build32, and 64-bit target data goes into build.  So, include/link the
+    # appropriate data at build time.
+    if (CMAKE_CL_64)
+        set (BUILDTGT_DIR build)
+    else ()
+        set (BUILDTGT_DIR build32)
+    endif()
+
+    # Use static MSVCRT libraries
+    foreach(configuration in CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_RELWITHDEBINFO
+                             CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+        if(${configuration} MATCHES "/MD")
+            string(REGEX REPLACE "/MD" "/MT" ${configuration} "${${configuration}}")
+        endif()
+    endforeach()
+
+endif()
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+
+if(WIN32)
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
+endif()
+
+include_directories(
+    ${DEMO_INCLUDE_DIRS}
+    ${VULKAN_VIDEO_APIS_INCLUDE}
+    ${VULKAN_VIDEO_APIS_INCLUDE}/vulkan
+    )
+
+######################################################################################
+
+
+install(TARGETS DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+######################################################################################
+# vk-video-dec
+if ((${CMAKE_SYSTEM_PROCESSOR} STREQUAL ${CMAKE_HOST_SYSTEM_PROCESSOR}))
+    if ((DEMOS_WSI_SELECTION STREQUAL "XCB") OR (DEMOS_WSI_SELECTION STREQUAL "WAYLAND") OR WIN32)
+        add_subdirectory(vk-video-trans)
+    endif()
+endif()

--- a/vk_video_transcoder/demos/vk-video-trans/CMakeLists.txt
+++ b/vk_video_transcoder/demos/vk-video-trans/CMakeLists.txt
@@ -1,0 +1,237 @@
+set (_TRANSCODING 1)
+if (${_TRANSCODING} MATCHES 1)
+    set(TARGET_EXECUTABLE_NAME vk-video-trans-test)
+    add_compile_definitions(_TRANSCODING)
+else()
+    set(TARGET_EXECUTABLE_NAME vk-video-dec-test)
+endif()
+set(sources Main.cpp)
+
+# ---- Encoder sources (transcoding only) ----
+IF (${_TRANSCODING} MATCHES 1)
+list(APPEND sources
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfigH264.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfigH264.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderDpbH264.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderDpbH264.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderH264.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderH264.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfigH265.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfigH265.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderDpbH265.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderDpbH265.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderH265.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderH265.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfigAV1.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfigAV1.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderDpbAV1.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderDpbAV1.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderAV1.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderAV1.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkEncoderConfig.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoder.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderPsnr.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoderPsnr.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/json/EncoderConfigJsonLoader.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoGopStructure.cpp
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoGopStructure.h
+    ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}/VkVideoEncoder/VkVideoEncoder.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/YCbCrConvUtilsCpu.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/YCbCrConvUtilsCpu.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoImagePool.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoImagePool.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanQueryPoolSet.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanQueryPoolSet.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoSessionParameters.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoSessionParameters.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoDisplayQueue.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoDisplayQueue.h)
+ENDIF()
+
+# ---- Common (decoder) sources ----
+list(APPEND sources
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkShell/Shell.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkShell/ShellDirect.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkShell/Shell.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/Helpers.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/HelpersDispatchTable.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/HelpersDispatchTable.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDeviceContext.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDeviceContext.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanShaderCompiler.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanShaderCompiler.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDeviceMemoryImpl.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDeviceMemoryImpl.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VkBufferResource.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VkBufferResource.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VkImageResource.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VkImageResource.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDescriptorSetLayout.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDescriptorSetLayout.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanCommandBuffersSet.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanCommandBuffersSet.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanComputePipeline.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanComputePipeline.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoSession.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoSession.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoSessionParameters.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoSessionParameters.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/FrameProcessor.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoProcessor.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoProcessor.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFrame.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFrame.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/pattern.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/pattern.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoUtils.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoUtils.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFilter.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFilter.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFilterYuvCompute.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFilterYuvCompute.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanSamplerYcbcrConversion.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanSamplerYcbcrConversion.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFenceSet.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFenceSet.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanSemaphoreSet.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanSemaphoreSet.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VkVideoRefCountBase.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/nvVkFormats.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanBistreamBufferImpl.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanBistreamBufferImpl.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanCommandBufferPool.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanCommandBufferPool.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VkVideoFrameToFile.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VkVideoCrc.cpp
+    ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkDecoderUtils/VideoStreamDemuxer.cpp
+    ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkDecoderUtils/VideoStreamDemuxer.h
+    ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkDecoderUtils/ElementaryStream.cpp
+    ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkVideoDecoder/VkVideoDecoder.cpp
+    ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkVideoDecoder/VkVideoDecoder.h
+    ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkVideoParser/VulkanVideoParser.cpp
+    ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkVideoDecoder/VkParserVideoPictureParameters.h
+    ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkVideoDecoder/VkParserVideoPictureParameters.cpp
+    ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.h
+    ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.cpp
+    )
+
+# Conditionally include FFmpegDemuxer.cpp
+if(FFMPEG_AVAILABLE)
+    list(APPEND sources ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkDecoderUtils/FFmpegDemuxer.cpp)
+endif()
+
+set(definitions
+    PRIVATE -DVK_NO_PROTOTYPES
+    PRIVATE -DGLM_FORCE_RADIANS
+    PRIVATE -DVIDEO_DISPLAY_QUEUE_SUPPORT)
+
+# Conditionally include FFMPEG_DEMUXER_SUPPORT
+if(FFMPEG_AVAILABLE)
+    list(APPEND definitions PRIVATE -DFFMPEG_DEMUXER_SUPPORT)
+endif()
+
+set(includes
+    PRIVATE ${VK_VIDEO_ENCODER_LIBS_SOURCE_ROOT}
+    PRIVATE ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}
+    PRIVATE ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}
+    PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+set(libraries PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+
+# Extract the directory part of the Vulkan library path
+get_filename_component(VULKAN_LIB_DIR "${Vulkan_LIBRARIES}" DIRECTORY)
+
+# Link against shared FFmpeg from LD_LIBRARY_PATH (export before cmake, not only cmake --build):
+#   export LD_LIBRARY_PATH=<prefix>/libavcodec:<prefix>/libavformat:<prefix>/libavutil:...
+# LD_LIBRARY_PATH is used by the runtime loader; CMake reads it at configure time here so
+# -lav* resolves to those shared libs instead of static libav*.a under /usr/local/lib.
+set(_ffmpeg_ld_lib_dirs "")
+if(DEFINED ENV{LD_LIBRARY_PATH} AND NOT "$ENV{LD_LIBRARY_PATH}" STREQUAL "")
+    string(REPLACE ":" ";" _ffmpeg_ld_lib_dirs "$ENV{LD_LIBRARY_PATH}")
+    link_directories(BEFORE ${_ffmpeg_ld_lib_dirs})
+endif()
+
+link_directories(
+    ${VULKAN_VIDEO_DEVICE_LIBS_PATH}
+    ${VULKAN_VIDEO_DEC_LIBS_PATH}
+    ${VULKAN_VIDEO_PARSER_LIB_PATH}
+    ${LIBNVPARSER_BINARY_ROOT}
+    ${VULKAN_LIB_DIR}
+    )
+
+if(WIN32)
+    list(APPEND libraries PUBLIC ${AVCODEC_LIB} ${AVFORMAT_LIB} ${AVUTIL_LIB} ${VULKAN_VIDEO_PARSER_LIB} ${SHADERC_LIB_SHARED})
+else()
+    list(APPEND libraries PRIVATE -lX11)
+    if(_ffmpeg_ld_lib_dirs)
+        find_library(_ffmpeg_avcodec_lib NAMES avcodec PATHS ${_ffmpeg_ld_lib_dirs} NO_DEFAULT_PATH)
+        find_library(_ffmpeg_avutil_lib NAMES avutil PATHS ${_ffmpeg_ld_lib_dirs} NO_DEFAULT_PATH)
+        find_library(_ffmpeg_avformat_lib NAMES avformat PATHS ${_ffmpeg_ld_lib_dirs} NO_DEFAULT_PATH)
+    endif()
+    if(_ffmpeg_avcodec_lib AND _ffmpeg_avutil_lib AND _ffmpeg_avformat_lib)
+        list(APPEND libraries PRIVATE ${_ffmpeg_avformat_lib} ${_ffmpeg_avcodec_lib} ${_ffmpeg_avutil_lib})
+    else()
+        list(APPEND libraries PRIVATE -lavcodec -lavutil -lavformat)
+    endif()
+    list(APPEND libraries PRIVATE ${SHADERC_SHARED_LIBRARY})
+    list(APPEND libraries PRIVATE -L${CMAKE_INSTALL_LIBDIR} -l${VULKAN_VIDEO_PARSER_LIB})
+    list(APPEND libraries PRIVATE -L${LIBNVPARSER_BINARY_ROOT} -l${VULKAN_VIDEO_PARSER_LIB})
+endif()
+
+if(TARGET vulkan)
+    list(APPEND definitions PRIVATE -DUNINSTALLED_LOADER="$<TARGET_FILE:vulkan>")
+endif()
+
+if(WIN32)
+    list(APPEND definitions PRIVATE -DVK_USE_PLATFORM_WIN32_KHR)
+    list(APPEND definitions PRIVATE -DWIN32_LEAN_AND_MEAN)
+
+    list(APPEND sources ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkShell/ShellWin32.cpp ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkShell/ShellWin32.h)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    list(APPEND libraries PRIVATE -ldl -lrt -lpthread)
+
+    if(BUILD_WSI_XCB_SUPPORT AND DEMOS_WSI_SELECTION STREQUAL "XCB")
+        find_package(XCB REQUIRED)
+
+        list(APPEND sources ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkShell/ShellXcb.cpp ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkShell/ShellXcb.h)
+        list(APPEND definitions PRIVATE -DVK_USE_PLATFORM_XCB_KHR)
+        list(APPEND includes PRIVATE ${XCB_INCLUDES})
+        list(APPEND libraries PRIVATE ${XCB_LIBRARIES})
+    elseif(BUILD_WSI_WAYLAND_SUPPORT AND DEMOS_WSI_SELECTION STREQUAL "WAYLAND")
+        find_package(Wayland REQUIRED)
+
+        list(APPEND sources ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkShell/ShellWayland.cpp ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkShell/ShellWayland.h)
+        list(APPEND definitions PRIVATE -DVK_USE_PLATFORM_WAYLAND_KHR)
+        list(APPEND includes PRIVATE ${WAYLAND_CLIENT_INCLUDE_DIR})
+        list(APPEND libraries PRIVATE ${WAYLAND_CLIENT_LIBRARIES})
+    endif()
+endif()
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..)
+
+list(APPEND includes PRIVATE ${VK_VIDEO_DECODER_LIBS_INCLUDE_ROOT})
+list(APPEND includes PRIVATE ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT})
+list(APPEND includes PRIVATE ${VULKAN_VIDEO_PARSER_INCLUDE})
+list(APPEND includes PRIVATE ${VULKAN_VIDEO_APIS_INCLUDE})
+list(APPEND includes PRIVATE ${VULKAN_VIDEO_APIS_INCLUDE}/vulkan)
+list(APPEND includes PRIVATE ${VULKAN_VIDEO_APIS_INCLUDE}/nvidia_utils/vulkan)
+
+add_executable(${TARGET_EXECUTABLE_NAME} ${sources})
+target_compile_definitions(${TARGET_EXECUTABLE_NAME} ${definitions})
+target_include_directories(${TARGET_EXECUTABLE_NAME} ${includes})
+target_link_libraries(${TARGET_EXECUTABLE_NAME} PUBLIC ${libraries} simdjson::simdjson)
+add_dependencies(${TARGET_EXECUTABLE_NAME} GenerateDispatchTables ${VULKAN_VIDEO_PARSER_LIB} ${SHADERC_LIB})
+
+# Add NV_AQ_GPU_LIB_SUPPORTED definition and include paths if the library is available
+if(NV_AQ_GPU_LIB_AVAILABLE)
+    target_compile_definitions(${TARGET_EXECUTABLE_NAME} PRIVATE NV_AQ_GPU_LIB_SUPPORTED=1)
+    if(NV_AQ_GPU_LIB_INCLUDE_DIRS)
+        target_include_directories(${TARGET_EXECUTABLE_NAME} PRIVATE ${NV_AQ_GPU_LIB_INCLUDE_DIRS})
+    endif()
+    if(TARGET ${NV_AQ_GPU_LIB_TARGET})
+        target_link_libraries(${TARGET_EXECUTABLE_NAME} PUBLIC ${NV_AQ_GPU_LIB_TARGET})
+        add_dependencies(${TARGET_EXECUTABLE_NAME} ${NV_AQ_GPU_LIB_TARGET})
+    endif()
+endif()
+
+install(TARGETS ${TARGET_EXECUTABLE_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/vk_video_transcoder/demos/vk-video-trans/Main.cpp
+++ b/vk_video_transcoder/demos/vk-video-trans/Main.cpp
@@ -1,0 +1,379 @@
+/*
+ * Copyright (C) 2016 Google, Inc.
+ * Copyright 2020 NVIDIA Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <string>
+#include <vector>
+#include <cstring>
+#include <cstdio>
+
+#include "VkCodecUtils/VulkanDeviceContext.h"
+#include "VkCodecUtils/DecoderConfig.h"
+#include "VkCodecUtils/VulkanVideoProcessor.h"
+#include "VkCodecUtils/VulkanDecoderFrameProcessor.h"
+#include "VkShell/Shell.h"
+
+#if (_TRANSCODING)
+#include "VkVideoEncoder/VkVideoEncoder.h"
+#include "VkVideoEncoder/VkEncoderConfig.h"
+#include "VkCodecUtils/VulkanVideoDisplayQueue.h"
+#include "VkCodecUtils/VulkanVideoEncodeDisplayQueue.h"
+#include "VkCodecUtils/VulkanEncoderFrameProcessor.h"
+#endif
+
+int main(int argc, const char **argv) {
+
+    DecoderConfig decoderConfig(argv[0]);
+    decoderConfig.ParseArgs(argc, argv);
+
+    VkSharedBaseObj<VideoStreamDemuxer> videoStreamDemuxer;
+    VkResult result = VideoStreamDemuxer::Create(decoderConfig.videoFileName.c_str(),
+                                        decoderConfig.forceParserType,
+                                        decoderConfig.enableStreamDemuxing,
+                                        decoderConfig.initialWidth,
+                                        decoderConfig.initialHeight,
+                                        decoderConfig.initialBitdepth,
+                                        videoStreamDemuxer);
+    if (result != VK_SUCCESS) {
+        assert(!"Can't initialize the VideoStreamDemuxer!");
+    }
+
+    static const char* const requiredInstanceLayers[] = {
+        "VK_LAYER_KHRONOS_validation",
+        nullptr
+    };
+
+#if (_TRANSCODING)
+    decoderConfig.enableVideoEncoder = 1;
+    decoderConfig.noPresent = 1;
+    VkSharedBaseObj<EncoderConfig> encoderConfig;
+    if (VK_SUCCESS != EncoderConfig::CreateCodecConfig(argc, argv, encoderConfig)) {
+        return -1;
+    }
+    encoderConfig->enablePreprocessComputeFilter = false;
+    if (encoderConfig->numEncoderResizedOutputs > 0) {
+        decoderConfig.enablePostProcessFilter = VulkanFilterYuvCompute::RESIZE;
+    }
+    const int32_t numEncodeQueues = 2;  // only one HW encoder instance
+#endif //_TRANSCODING
+
+
+    static const char* const requiredInstanceExtensions[] = {
+        VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
+        nullptr
+    };
+
+    static const char* const requiredWsiInstanceExtensions[] = {
+        // Required generic WSI extensions
+        VK_KHR_SURFACE_EXTENSION_NAME,
+        nullptr
+    };
+
+    static const char* const requiredDeviceExtension[] = {
+#if defined(__linux) || defined(__linux__) || defined(linux)
+        VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+        VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME,
+#endif
+        VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME,
+        VK_KHR_VIDEO_QUEUE_EXTENSION_NAME,
+        VK_KHR_VIDEO_DECODE_QUEUE_EXTENSION_NAME,
+        VK_KHR_VIDEO_ENCODE_QUEUE_EXTENSION_NAME,
+        VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
+#if _TRANSCODING
+        VK_KHR_VIDEO_ENCODE_QUEUE_EXTENSION_NAME,
+        VK_KHR_VIDEO_MAINTENANCE_1_EXTENSION_NAME,
+#endif
+        nullptr
+    };
+
+    static const char* const requiredWsiDeviceExtension[] = {
+        // Add the WSI required device extensions
+        VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+#if !defined(VK_USE_PLATFORM_WIN32_KHR)
+        // VK_EXT_DISPLAY_CONTROL_EXTENSION_NAME,
+#endif
+        nullptr
+    };
+
+    static const char* const optinalDeviceExtension[] = {
+        VK_EXT_YCBCR_2PLANE_444_FORMATS_EXTENSION_NAME,
+        VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME,
+        VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
+        VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME,
+        VK_KHR_VIDEO_MAINTENANCE_1_EXTENSION_NAME,
+        nullptr
+    };
+
+    VulkanDeviceContext vkDevCtxt;
+
+    if (decoderConfig.validate) {
+        vkDevCtxt.AddReqInstanceLayers(requiredInstanceLayers);
+        vkDevCtxt.AddReqInstanceExtensions(requiredInstanceExtensions);
+    }
+
+    // Add the Vulkan video required device extensions
+    vkDevCtxt.AddReqDeviceExtensions(requiredDeviceExtension);
+    vkDevCtxt.AddOptDeviceExtensions(optinalDeviceExtension);
+
+    /********** Start WSI instance extensions support *******************************************/
+    if (!decoderConfig.noPresent) {
+        const std::vector<VkExtensionProperties>& wsiRequiredInstanceInstanceExtensions =
+                Shell::GetRequiredInstanceExtensions(decoderConfig.directMode);
+
+        for (size_t e = 0; e < wsiRequiredInstanceInstanceExtensions.size(); e++) {
+            vkDevCtxt.AddReqInstanceExtension(wsiRequiredInstanceInstanceExtensions[e].extensionName);
+        }
+
+        // Add the WSI required instance extensions
+        vkDevCtxt.AddReqInstanceExtensions(requiredWsiInstanceExtensions);
+
+        // Add the WSI required device extensions
+        vkDevCtxt.AddReqDeviceExtensions(requiredWsiDeviceExtension);
+    }
+    /********** End WSI instance extensions support *******************************************/
+
+    VkVideoCodecOperationFlagsKHR videoCodecOperation = (VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR  |
+                                                       VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR  |
+                                                       VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR);
+
+    VkVideoCodecOperationFlagsKHR videoCodecs = videoCodecOperation;
+
+#if (_TRANSCODING)
+    VkVideoCodecOperationFlagsKHR videoEncodeCodecs = ( VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR  |
+                                                        VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR  |
+                                                        VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR);
+    videoCodecs |= videoEncodeCodecs;
+#endif
+
+    // VulkanDeviceContext vkDevCtxt;
+    result = vkDevCtxt.InitVulkanDecoderDevice(decoderConfig.appName.c_str(),
+                                                        VK_NULL_HANDLE,
+                                                        videoCodecs, // previously: videoCodecOperation
+                                                        !decoderConfig.noPresent,
+                                                        decoderConfig.directMode,
+                                                        decoderConfig.validate,
+                                                        decoderConfig.validateVerbose,
+                                                        decoderConfig.verbose);
+
+    if (result != VK_SUCCESS) {
+        printf("Could not initialize the Vulkan decoder device!\n");
+        return -1;
+    }
+
+    const bool supportsDisplay = true;
+    const int32_t numDecodeQueues = ((decoderConfig.queueId != 0) ||
+                                     (decoderConfig.enableHwLoadBalancing != 0)) ?
+                                     -1 : // all available HW decoders
+                                      1;  // only one HW decoder instance
+
+    VkQueueFlags requestVideoDecodeQueueMask = VK_QUEUE_VIDEO_DECODE_BIT_KHR;
+
+    VkQueueFlags requestVideoEncodeQueueMask = 0;
+    if (decoderConfig.enableVideoEncoder) {
+        requestVideoEncodeQueueMask |= VK_QUEUE_VIDEO_ENCODE_BIT_KHR;
+    }
+
+    if (decoderConfig.selectVideoWithComputeQueue) {
+        requestVideoDecodeQueueMask |= VK_QUEUE_COMPUTE_BIT;
+        if (decoderConfig.enableVideoEncoder) {
+            requestVideoEncodeQueueMask |= VK_QUEUE_COMPUTE_BIT;
+        }
+    }
+
+    VkQueueFlags requestVideoComputeQueueMask = 0;
+    if (decoderConfig.enablePostProcessFilter != -1) {
+        requestVideoComputeQueueMask = VK_QUEUE_COMPUTE_BIT;
+    }
+
+    if (supportsDisplay && !decoderConfig.noPresent) {
+        VkSharedBaseObj<Shell> displayShell;
+        const Shell::Configuration configuration(decoderConfig.appName.c_str(),
+                                                 decoderConfig.backBufferCount,
+                                                 decoderConfig.directMode);
+
+        result = Shell::Create(&vkDevCtxt, configuration, displayShell);
+        if (result != VK_SUCCESS) {
+            assert(!"Can't allocate display shell! Out of memory!");
+            return -1;
+        }
+
+        result = vkDevCtxt.InitPhysicalDevice(decoderConfig.deviceId, decoderConfig.deviceUUID,
+                                              (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_TRANSFER_BIT |
+                                              requestVideoComputeQueueMask |
+                                              requestVideoDecodeQueueMask |
+                                              requestVideoEncodeQueueMask),
+                                              displayShell.get(),
+                                              requestVideoDecodeQueueMask,
+                                              (VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR |
+                                               VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR |
+                                               VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR),
+                                              requestVideoEncodeQueueMask,
+                                              (VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR |
+                                               VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR |
+                                               VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR));
+        if (result != VK_SUCCESS) {
+
+            assert(!"Can't initialize the Vulkan physical device!");
+            return -1;
+        }
+        assert(displayShell->PhysDeviceCanPresent(vkDevCtxt.getPhysicalDevice(),
+                                                   vkDevCtxt.GetPresentQueueFamilyIdx()));
+
+
+        vkDevCtxt.CreateVulkanDevice(numDecodeQueues,
+                                     decoderConfig.enableVideoEncoder ? 1 : 0, // num encode queues
+                                     videoCodecs,
+                                     false, //  createTransferQueue
+                                     true,  // createGraphicsQueue
+                                     true,  // createDisplayQueue
+                                     requestVideoComputeQueueMask != 0  // createComputeQueue
+                                     );
+
+        VkSharedBaseObj<VulkanVideoProcessor> vulkanVideoProcessor;
+        result = VulkanVideoProcessor::Create(decoderConfig, &vkDevCtxt, vulkanVideoProcessor);
+        if (result != VK_SUCCESS) {
+            return -1;
+        }
+
+        VkSharedBaseObj<VkVideoFrameOutput> frameToFile;
+#if (!_TRANSCODING)
+        if (!decoderConfig.outputFileName.empty()) {
+            const char* crcOutputFile = decoderConfig.outputcrcPerFrame ? decoderConfig.crcOutputFileName.c_str() : nullptr;
+            result = VkVideoFrameOutput::Create(decoderConfig.outputFileName.c_str(),
+                                              decoderConfig.outputy4m,
+                                              decoderConfig.outputcrcPerFrame,
+                                              crcOutputFile,
+                                              decoderConfig.crcInitValue,
+                                              frameToFile);
+            if (result != VK_SUCCESS) {
+                fprintf(stderr, "Error creating output file %s\n", decoderConfig.outputFileName.c_str());
+                return -1;
+            }
+        }
+#endif
+
+        vulkanVideoProcessor->Initialize(&vkDevCtxt, videoStreamDemuxer, frameToFile, decoderConfig);
+
+        VkSharedBaseObj<VkVideoQueue<VulkanDecodedFrame>> videoQueue(vulkanVideoProcessor);
+        DecoderFrameProcessorState frameProcessor(&vkDevCtxt, videoQueue, 0);
+
+        displayShell->AttachFrameProcessor(frameProcessor);
+
+        displayShell->RunLoop();
+
+    } else {
+
+        result = vkDevCtxt.InitPhysicalDevice(decoderConfig.deviceId, decoderConfig.deviceUUID,
+                                              (VK_QUEUE_TRANSFER_BIT        | 
+                                              requestVideoDecodeQueueMask  |
+                                              requestVideoComputeQueueMask |
+                                              requestVideoEncodeQueueMask),
+                                              nullptr,
+                                              requestVideoDecodeQueueMask);
+        if (result != VK_SUCCESS) {
+
+            assert(!"Can't initialize the Vulkan physical device!");
+            return -1;
+        }
+
+
+        result = vkDevCtxt.CreateVulkanDevice(numDecodeQueues,  // numDecodeQueues
+#if (_TRANSCODING)
+                                              numEncodeQueues,
+#else
+                                              0,     // num encode queues
+#endif //_TRANSCODING
+                                              videoCodecs,
+                                              // If no graphics or compute queue is requested, only video queues
+                                              // will be created. Not all implementations support transfer on video queues,
+                                              // so request a separate transfer queue for such implementations.
+                                              ((vkDevCtxt.GetVideoDecodeQueueFlag() & VK_QUEUE_TRANSFER_BIT) == 0), //  createTransferQueue
+                                              false, // createGraphicsQueue
+                                              false, // createDisplayQueue
+                                              requestVideoComputeQueueMask != 0   // createComputeQueue
+                                              );
+        if (result != VK_SUCCESS) {
+
+            assert(!"Failed to create Vulkan device!");
+            return -1;
+        }
+
+        VkSharedBaseObj<VulkanVideoProcessor> vulkanVideoProcessor;
+        result = VulkanVideoProcessor::Create(decoderConfig, &vkDevCtxt, vulkanVideoProcessor);
+        if (result != VK_SUCCESS) {
+            std::cerr << "Error creating the decoder instance: " << result << std::endl;
+            return -1;
+        }
+
+        VkSharedBaseObj<VkVideoFrameOutput> frameToFile;
+#if (!_TRANSCODING)
+        if (!decoderConfig.outputFileName.empty()) {
+            const char* crcOutputFile = decoderConfig.outputcrcPerFrame ? decoderConfig.crcOutputFileName.c_str() : nullptr;
+            result = VkVideoFrameOutput::Create(decoderConfig.outputFileName.c_str(),
+                                              decoderConfig.outputy4m,
+                                              decoderConfig.outputcrcPerFrame,
+                                              crcOutputFile,
+                                              decoderConfig.crcInitValue,
+                                              frameToFile);
+            if (result != VK_SUCCESS) {
+                fprintf(stderr, "Error creating output file %s\n", decoderConfig.outputFileName.c_str());
+                return -1;
+            }
+        }
+#endif
+
+        vulkanVideoProcessor->Initialize(&vkDevCtxt, videoStreamDemuxer, frameToFile, decoderConfig);
+
+        VkSharedBaseObj<VkVideoQueue<VulkanDecodedFrame>> videoQueue(vulkanVideoProcessor);
+        DecoderFrameProcessorState frameProcessor(&vkDevCtxt, videoQueue, decoderConfig.decoderQueueSize);
+
+        const int numberOfFrames = decoderConfig.decoderQueueSize;
+        int ret = frameProcessor->CreateFrameData(numberOfFrames);
+        assert(ret == numberOfFrames);
+        if (ret != numberOfFrames) {
+            return -1;
+        }
+#if (_TRANSCODING)
+    int curFrameIndex = 0;
+#endif // _TRANSCODING
+        bool continueLoop = true;
+        do {
+#if (_TRANSCODING)
+            continueLoop = frameProcessor->OnFrameTranscoding(0, &decoderConfig, encoderConfig);
+            curFrameIndex++;
+#else
+            continueLoop = frameProcessor->OnFrame(0);
+#endif //_TRANSCODING
+        } while (continueLoop);
+#if (_TRANSCODING)
+        int i = 0;
+        do {
+            vulkanVideoProcessor->getEncoder(i)->WaitForThreadsToComplete();
+            std::string outputFilename = encoderConfig->numEncoderResizedOutputs == 0 ?
+                                        encoderConfig->outputFileHandler.GetFileName() :
+                                        encoderConfig->resizedOutputFileHandler[i].GetFileName();
+            std::cout << "Done processing " << curFrameIndex << " input frames!" << std::endl
+                    << "Encoded file's location is at " << outputFilename
+                    << std::endl;
+            i++;
+        }  while (i < encoderConfig->numEncoderResizedOutputs);
+#endif // _TRANSCODING
+        frameProcessor->DestroyFrameData();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
A brief explanation

Transcoding is an extension of the decoder - it is based on both the decoder and the encoder
- transcoding from one codec to another is supported (you can specify a target bitrate, a vbv buffer relative size, vbr or cbr as well);
- transcoding to multiple different resolutions.

Transcoder specific changes are put together with the decoder's and the encoder's code because from maintenance and support points of view it would be time consuming to track and update everything from the decoder and the encoder. My goal was to minimize the code duplication and efforts for the code maintenance and support (however the transcoder has it's separate own project folder and Main).

The transcoder can be built from it's own folder using CMake in the same way as for the decoder or the encoder (see Build.md in the transcoder's folder). 

cmdline example:
./demos/vk-video-trans-test -i input_file_to_reencode  --codec hevc --qualityLevel 3 --profile 0 --bitrate 5  --vbvbuf-ratio 2 --numberResizedOutputs 3 1280x720 800x600 352x288