### PR TITLE
Return error if the specified qualityLevel is greater than the maximu…

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -578,6 +578,13 @@ VkResult VkVideoEncoder::InitEncoder(VkSharedBaseObj<EncoderConfig>& encoderConf
 
     encoderConfig->InitDeviceCapabilities(m_vkDevCtx);
 
+    if (encoderConfig->qualityLevel >= encoderConfig->videoEncodeCapabilities.maxQualityLevels) {
+        std::cerr << "Quality level " << encoderConfig->qualityLevel
+                  << " is greater than the maximum supported quality level "
+                  << (encoderConfig->videoEncodeCapabilities.maxQualityLevels - 1) << std::endl;
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
     if (encoderConfig->useDpbArray == false &&
         (encoderConfig->videoCapabilities.flags & VK_VIDEO_CAPABILITY_SEPARATE_REFERENCE_IMAGES_BIT_KHR) == 0) {
         std::cout << "Separate DPB was requested, but the implementation does not support it!" << std::endl;


### PR DESCRIPTION
The number of quality levels supported by the implementation can vary for each codec and may also depend on other parameters.

Therefore, if a client specifies a qualityLevel that is not supported by the implementation, this change fails encode initialization. 

Even if the client attempts to use out-of-range values by disabling this check, the validation layer must catch this error if it is enabled. The implementation may either clamp the value to a valid range or return an error.