### PR TITLE
Fixed setting quality level (validation layer warning)

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.cpp
@@ -72,6 +72,15 @@ VkResult VkVideoEncoderH264::InitEncoderCodec(VkSharedBaseObj<EncoderConfig>& en
     VkVideoSessionParametersCreateInfoKHR* encodeSessionParametersCreateInfo = videoSessionParametersInfo.getVideoSessionParametersInfo();
     encodeSessionParametersCreateInfo->flags = 0;
     VkVideoSessionParametersKHR sessionParameters;
+
+    VkVideoEncodeQualityLevelInfoKHR qualityLevel;
+    qualityLevel.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR;
+    qualityLevel.pNext = nullptr;
+    qualityLevel.qualityLevel = encoderConfig->qualityLevel;
+
+    VkVideoEncodeH264SessionParametersCreateInfoKHR* encodeH264SessionParametersCreateInfo = (VkVideoEncodeH264SessionParametersCreateInfoKHR*)encodeSessionParametersCreateInfo->pNext;
+    encodeH264SessionParametersCreateInfo->pNext = &qualityLevel;
+
     result = m_vkDevCtx->CreateVideoSessionParametersKHR(*m_vkDevCtx,
                                                          encodeSessionParametersCreateInfo,
                                                          nullptr,


### PR DESCRIPTION
VUID-vkCmdEncodeVideoKHR-None-08318(ERROR / SPEC): msgNum: 1..1 - Validation Error: [ VUID-vkCmdEncodeVideoKHR-None-08318 ] Object 0: handle = 0x..1, type = VK_OBJECT_TYPE_VIDEO_SESSION_KHR; Object 1: handle = 0x..5, type = VK_OBJECT_TYPE_VIDEO_SESSION_PARAMETERS_KHR; | MessageID = 0x..9 | vkCmdEncodeVideoKHR(): The currently configured encode quality level (4) for VkVideoSessionKHR 0x..1[] does not match the encode quality level (0) VkVideoSessionParametersKHR 0x..5[] was created with.

"Video session parameters objects created with an encode operation are always created with respect to a video encode quality level. By default, the created video session parameters objects are created with quality level zero, unless otherwise specified by including a structure in the pCreateInfo->pNext chain, in which case the video session parameters object is created with the quality level specified in VkVideoEncodeQualityLevelInfoKHR::qualityLevel."