### PR TITLE
Fixed quality level validation layer warning

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
@@ -110,6 +110,7 @@ VkResult VkVideoEncoderAV1::InitEncoderCodec(VkSharedBaseObj<EncoderConfig>& enc
     VideoSessionParametersInfoAV1 videoSessionParametersInfo(*m_videoSession, &m_stateAV1.m_sequenceHeader,
                                                           nullptr/*decoderModelInfo*/,
                                                           1, m_stateAV1.m_operatingPointsInfo /*operatingPointsInfo*/,
+                                                          encoderConfig->qualityLevel,
                                                           encoderConfig->enableQpMap, m_qpMapTexelSize);
     VkVideoSessionParametersCreateInfoKHR* encodeSessionParametersCreateInfo = videoSessionParametersInfo.getVideoSessionParametersInfo();
     VkVideoSessionParametersKHR sessionParameters;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.cpp
@@ -66,6 +66,7 @@ VkResult VkVideoEncoderH264::InitEncoderCodec(VkSharedBaseObj<EncoderConfig>& en
     VideoSessionParametersInfo videoSessionParametersInfo(*m_videoSession,
                                                           &m_h264.m_spsInfo,
                                                           &m_h264.m_ppsInfo,
+                                                          m_encoderConfig->qualityLevel,
                                                           m_encoderConfig->enableQpMap,
                                                           m_qpMapTexelSize);
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.cpp
@@ -77,9 +77,14 @@ VkResult VkVideoEncoderH265::InitEncoderCodec(VkSharedBaseObj<EncoderConfig>& en
     encodeH265SessionParametersAddInfo.stdPPSCount = 1;
     encodeH265SessionParametersAddInfo.pStdPPSs = &m_pps;
 
+    VkVideoEncodeQualityLevelInfoKHR qualityLevelInfo;
+    qualityLevelInfo.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR;
+    qualityLevelInfo.pNext = nullptr;
+    qualityLevelInfo.qualityLevel = encoderConfig->qualityLevel;
+
     VkVideoEncodeH265SessionParametersCreateInfoKHR encodeH265SessionParametersCreateInfo = {
         VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_CREATE_INFO_KHR,
-        NULL, 1 /* maxStdVPSCount */, 1 /* maxSpsStdCount */, 1 /* maxPpsStdCount */,
+        &qualityLevelInfo, 1 /* maxStdVPSCount */, 1 /* maxSpsStdCount */, 1 /* maxPpsStdCount */,
         &encodeH265SessionParametersAddInfo
     };
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderStateAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderStateAV1.h
@@ -24,6 +24,7 @@ public:
                                StdVideoEncodeAV1DecoderModelInfo* decoderModel,
                                uint32_t operatingPointsCnt,
                                StdVideoEncodeAV1OperatingPointInfo* opInfo,
+                               uint32_t qualityLevel,
                                bool enableQpMap, VkExtent2D quantizationMapTexelSize)
     {
         m_videoSession = videoSession;
@@ -41,12 +42,18 @@ public:
         m_sessionParametersCreateInfo.videoSessionParametersTemplate = VK_NULL_HANDLE;
         m_sessionParametersCreateInfo.videoSession = m_videoSession;
 
+        m_qualityLevelInfo.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR;
+        m_qualityLevelInfo.pNext = nullptr;
+        m_qualityLevelInfo.qualityLevel = qualityLevel;
+
+        m_encodeAV1SessionParametersCreateInfo.pNext = &m_qualityLevelInfo;
+
         if (enableQpMap) {
             m_quantizationMapSessionParametersCreateInfo.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_SESSION_PARAMETERS_CREATE_INFO_KHR;
             m_quantizationMapSessionParametersCreateInfo.pNext = nullptr;
             m_quantizationMapSessionParametersCreateInfo.quantizationMapTexelSize = quantizationMapTexelSize;
 
-            m_encodeAV1SessionParametersCreateInfo.pNext = &m_quantizationMapSessionParametersCreateInfo;
+            m_qualityLevelInfo.pNext = &m_quantizationMapSessionParametersCreateInfo;
 
             m_sessionParametersCreateInfo.flags = VK_VIDEO_SESSION_PARAMETERS_CREATE_QUANTIZATION_MAP_COMPATIBLE_BIT_KHR;
         }
@@ -61,6 +68,7 @@ public:
 private:
     VkVideoSessionKHR m_videoSession;
     VkVideoEncodeAV1SessionParametersCreateInfoKHR m_encodeAV1SessionParametersCreateInfo;
+    VkVideoEncodeQualityLevelInfoKHR m_qualityLevelInfo;
     VkVideoEncodeQuantizationMapSessionParametersCreateInfoKHR m_quantizationMapSessionParametersCreateInfo;
     VkVideoSessionParametersCreateInfoKHR m_sessionParametersCreateInfo;
 };

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderStateH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderStateH264.h
@@ -22,6 +22,7 @@ public:
     VideoSessionParametersInfo(VkVideoSessionKHR videoSession,
                                StdVideoH264SequenceParameterSet* sps,
                                StdVideoH264PictureParameterSet* pps,
+                               uint32_t qualityLevel,
                                bool enableQpMap = false, VkExtent2D qpMapTexelSize = {0, 0})
     {
         m_videoSession = videoSession;
@@ -45,12 +46,19 @@ public:
         m_encodeSessionParametersCreateInfo.videoSessionParametersTemplate = VK_NULL_HANDLE;
         m_encodeSessionParametersCreateInfo.videoSession = m_videoSession;
 
+        m_qualityLevelInfo.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR;
+        m_qualityLevelInfo.pNext = nullptr;
+        m_qualityLevelInfo.qualityLevel = qualityLevel;
+
+        m_encodeH264SessionParametersCreateInfo.pNext = &m_qualityLevelInfo;
+
         if (enableQpMap) {
             m_encodeQuantizationMapSessionParametersCreateInfo.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_SESSION_PARAMETERS_CREATE_INFO_KHR;
             m_encodeQuantizationMapSessionParametersCreateInfo.pNext = nullptr;
             m_encodeQuantizationMapSessionParametersCreateInfo.quantizationMapTexelSize = qpMapTexelSize;
 
-            m_encodeH264SessionParametersCreateInfo.pNext = &m_encodeQuantizationMapSessionParametersCreateInfo;
+            m_qualityLevelInfo.pNext = &m_encodeQuantizationMapSessionParametersCreateInfo;
+
             m_encodeSessionParametersCreateInfo.flags = VK_VIDEO_SESSION_PARAMETERS_CREATE_QUANTIZATION_MAP_COMPATIBLE_BIT_KHR;
         }
     }
@@ -64,6 +72,7 @@ private:
     VkVideoEncodeH264SessionParametersAddInfoKHR m_encodeH264SessionParametersAddInfo;
     VkVideoEncodeH264SessionParametersCreateInfoKHR m_encodeH264SessionParametersCreateInfo;
     VkVideoSessionParametersCreateInfoKHR m_encodeSessionParametersCreateInfo;
+    VkVideoEncodeQualityLevelInfoKHR m_qualityLevelInfo;
     VkVideoEncodeQuantizationMapSessionParametersCreateInfoKHR m_encodeQuantizationMapSessionParametersCreateInfo;
 };
 


### PR DESCRIPTION
VUID-vkCmdEncodeVideoKHR-None-08318(ERROR / SPEC): msgNum: 1..1 - Validation Error: [ VUID-vkCmdEncodeVideoKHR-None-08318 ] Object 0: handle = 0x..1, type = VK_OBJECT_TYPE_VIDEO_SESSION_KHR; Object 1: handle = 0x..5, type = VK_OBJECT_TYPE_VIDEO_SESSION_PARAMETERS_KHR; | MessageID = 0x..9 | vkCmdEncodeVideoKHR(): The currently configured encode quality level (4) for VkVideoSessionKHR 0x..1[] does not match the encode quality level (0) VkVideoSessionParametersKHR 0x..5[] was created with.

"Video session parameters objects created with an encode operation are always created with respect to a video encode quality level. By default, the created video session parameters objects are created with quality level zero, unless otherwise specified by including a structure in the pCreateInfo->pNext chain, in which case the video session parameters object is created with the quality level specified in VkVideoEncodeQualityLevelInfoKHR::qualityLevel." [Vulkan Spec]