### PR TITLE
Report invalid cmdline arguments in h264 and hevc encoder

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -936,7 +936,17 @@ public:
 
     int ParseArguments(int argc, char *argv[]);
 
-    virtual int DoParseArguments(int argc, char *argv[]) { return 0; };
+    virtual int DoParseArguments(int argc, char *argv[]) {
+        if (argc > 0) {
+            std::cout << "Invalid paramters: ";
+            for (int i = 0; i < argc; i++) {
+                std::cout << argv[i] << " ";
+            }
+            std::cout << std::endl;
+            return -1;
+        }
+        return 0;
+    };
 
     virtual VkResult InitializeParameters()
     {


### PR DESCRIPTION
Exit and warn If command line string consists of invalid argument