### PR TITLE
Add intra refresh support

### DIFF
--- a/common/include/VkVideoCore/VulkanVideoCapabilities.h
+++ b/common/include/VkVideoCore/VulkanVideoCapabilities.h
@@ -68,9 +68,11 @@ public:
                                                VkVideoEncodeCapabilitiesKHR& videoEncodeCapabilities,
                                                VkVideoEncodeCodecCapabilitiesKHR& videoCodecCapabilities,
                                                VkVideoEncodeQuantizationMapCapabilitiesKHR& quantizationMapCapabilities,
-                                               VkVideoEncodeCodecQuantizationMapCapabilitiesKHR& codecQuantizationMapCapabilities) {
+                                               VkVideoEncodeCodecQuantizationMapCapabilitiesKHR& codecQuantizationMapCapabilities,
+                                               VkVideoEncodeIntraRefreshCapabilitiesKHR& intraRefreshCapabilities) {
 
-        codecQuantizationMapCapabilities = VkVideoEncodeCodecQuantizationMapCapabilitiesKHR { VK_STRUCTURE_TYPE_VIDEO_ENCODE_CODEC_QUANTIZATION_MAP_CAPABILITIES_KHR, nullptr };
+        intraRefreshCapabilities = VkVideoEncodeIntraRefreshCapabilitiesKHR { VK_STRUCTURE_TYPE_VIDEO_ENCODE_INTRA_REFRESH_CAPABILITIES_KHR, nullptr };
+        codecQuantizationMapCapabilities = VkVideoEncodeCodecQuantizationMapCapabilitiesKHR { VK_STRUCTURE_TYPE_VIDEO_ENCODE_CODEC_QUANTIZATION_MAP_CAPABILITIES_KHR, &intraRefreshCapabilities };
         quantizationMapCapabilities = VkVideoEncodeQuantizationMapCapabilitiesKHR { VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_CAPABILITIES_KHR, &codecQuantizationMapCapabilities };
         videoCodecCapabilities  = VkVideoEncodeCodecCapabilitiesKHR { VK_STRUCTURE_TYPE_VIDEO_ENCODE_CODEC_CAPABILITIES_KHR, &quantizationMapCapabilities };
         videoEncodeCapabilities = VkVideoEncodeCapabilitiesKHR { VK_STRUCTURE_TYPE_VIDEO_ENCODE_CAPABILITIES_KHR, &videoCodecCapabilities };
@@ -518,6 +520,17 @@ public:
 #else  // VK_KHR_video_maintenance1
         return false;
 #endif // VK_KHR_video_maintenance1
+    }
+
+    static bool IsVideoEncodeIntraRefreshSupported(const VulkanDeviceContext* vkDevCtx)
+    {
+        VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR intraRefreshFeatures{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_INTRA_REFRESH_FEATURES_KHR,
+                                                                                nullptr,
+                                                                                false};
+        VkPhysicalDeviceFeatures2 deviceFeatures{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &intraRefreshFeatures};
+        vkDevCtx->GetPhysicalDeviceFeatures2(vkDevCtx->getPhysicalDevice(),
+                                             &deviceFeatures);
+        return (intraRefreshFeatures.videoEncodeIntraRefresh == VK_TRUE);
     }
 
 };

--- a/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
+++ b/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
@@ -784,7 +784,12 @@ VkResult VulkanDeviceContext::CreateVulkanDevice(int32_t numDecodeQueues,
                                                                             VK_FALSE
                                                                            };
 
-        VkPhysicalDeviceFeatures2 deviceFeatures { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &synchronization2Features};
+        VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR intraRefreshFeatures { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_INTRA_REFRESH_FEATURES_KHR,
+                                                                                  &synchronization2Features,
+                                                                                  VK_FALSE
+                                                                                };
+
+        VkPhysicalDeviceFeatures2 deviceFeatures { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &intraRefreshFeatures};
         GetPhysicalDeviceFeatures2(m_physDevice, &deviceFeatures);
 
         assert(timelineSemaphoreFeatures.timelineSemaphore);

--- a/common/libs/VkCodecUtils/VulkanVideoSession.cpp
+++ b/common/libs/VkCodecUtils/VulkanVideoSession.cpp
@@ -32,9 +32,10 @@ VkResult VulkanVideoSession::Create(const VulkanDeviceContext* vkDevCtx,
                                     VkFormat            referencePicturesFormat,
                                     uint32_t            maxDpbSlots,
                                     uint32_t            maxActiveReferencePictures,
+                                    const void*         sessionCreateInfoChain,
                                     VkSharedBaseObj<VulkanVideoSession>& videoSession)
 {
-    VulkanVideoSession* pNewVideoSession = new VulkanVideoSession(vkDevCtx, pVideoProfile);
+    VulkanVideoSession* pNewVideoSession = new VulkanVideoSession(vkDevCtx, pVideoProfile, sessionCreateInfoChain);
 
     static const VkExtensionProperties h264DecodeStdExtensionVersion = { VK_STD_VULKAN_VIDEO_CODEC_H264_DECODE_EXTENSION_NAME, VK_STD_VULKAN_VIDEO_CODEC_H264_DECODE_SPEC_VERSION };
     static const VkExtensionProperties h265DecodeStdExtensionVersion = { VK_STD_VULKAN_VIDEO_CODEC_H265_DECODE_EXTENSION_NAME, VK_STD_VULKAN_VIDEO_CODEC_H265_DECODE_SPEC_VERSION };

--- a/common/libs/VkCodecUtils/VulkanVideoSession.h
+++ b/common/libs/VkCodecUtils/VulkanVideoSession.h
@@ -33,6 +33,7 @@ public:
                            VkFormat            referencePicturesFormat,
                            uint32_t            maxDpbSlots,
                            uint32_t            maxActiveReferencePictures,
+                           const void*         sessionCreateInfoChain,
                            VkSharedBaseObj<VulkanVideoSession>& videoSession);
 
     bool IsCompatible ( const VulkanDeviceContext* vkDevCtx,
@@ -114,9 +115,10 @@ public:
 private:
 
     VulkanVideoSession(const VulkanDeviceContext* vkDevCtx,
-                   VkVideoCoreProfile* pVideoProfile)
+                       VkVideoCoreProfile* pVideoProfile,
+                       const void* sessionCreateInfoChain)
        : m_refCount(0), m_flags(), m_profile(*pVideoProfile), m_vkDevCtx(vkDevCtx),
-         m_createInfo{ VK_STRUCTURE_TYPE_VIDEO_SESSION_CREATE_INFO_KHR, NULL },
+         m_createInfo{ VK_STRUCTURE_TYPE_VIDEO_SESSION_CREATE_INFO_KHR, sessionCreateInfoChain },
          m_videoSession(VkVideoSessionKHR()), m_memoryBound{}
     {
 

--- a/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
+++ b/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
@@ -232,6 +232,7 @@ int32_t VkVideoDecoder::StartVideoSequence(VkParserDetectedVideoFormat* pVideoFo
                                              dpbImageFormat,
                                              maxDpbSlotCount,
                                              std::min<uint32_t>(maxDpbSlotCount, VkParserPerFrameDecodeParameters::MAX_DPB_REF_SLOTS),
+                                             nullptr,
                                              m_videoSession);
 
         // after creating a new video session, we need codec reset.

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -77,7 +77,8 @@ static void printHelp(VkVideoCodecOperationFlagBitsKHR codec)
     }
 
     if ((codec == VK_VIDEO_CODEC_OPERATION_NONE_KHR) || (codec == VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR)) {
-        fprintf(stderr, "\nH265 specific arguments: None\n");
+        fprintf(stderr, "\nH265 specific arguments:\n\
+        --slices                        <integer> : Number of slices to divide the picture into\n");
     }
 
     if ((codec == VK_VIDEO_CODEC_OPERATION_NONE_KHR) || (codec == VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR)) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -72,7 +72,8 @@ static void printHelp(VkVideoCodecOperationFlagBitsKHR codec)
     --testOutOfOrderRecording                 : Testing only - enable testing for out-of-order-recording\n");
 
     if ((codec == VK_VIDEO_CODEC_OPERATION_NONE_KHR) || (codec == VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR)) {
-        fprintf(stderr, "\nH264 specific arguments: None\n");
+        fprintf(stderr, "\nH264 specific arguments:\n\
+        --slices                        <integer> : Number of slices to divide the picture into\n");
     }
 
     if ((codec == VK_VIDEO_CODEC_OPERATION_NONE_KHR) || (codec == VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR)) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -493,6 +493,10 @@ int EncoderConfig::ParseArguments(int argc, const char *argv[])
                 fprintf(stderr, "invalid parameter for %s\n", args[i - 1].c_str());
                 return -1;
             }
+            gopStructure.SetIntraRefreshCycleDuration(intraRefreshCycleDuration);
+            if (verbose) {
+                printf("Selected intraRefreshCycleDuration: %d\n", intraRefreshCycleDuration);
+            }
         } else if (args[i] == "--intraRefreshMode") {
             if (++i >= argc) {
                 fprintf(stderr, "Invalid paramter for %s\n", args[i - 1].c_str());

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -794,6 +794,7 @@ public:
     uint32_t intraRefreshCycleDuration;
     IntraRefreshMode intraRefreshMode;
     uint32_t intraRefreshCycleRestartIndex;
+    uint32_t intraRefreshSkippedStartIndex;
 
     // Vulkan Input color space and transfer characteristics parameters
     VkSamplerYcbcrModelConversion              ycbcrModel;
@@ -898,6 +899,7 @@ public:
     , intraRefreshCycleDuration(0)
     , intraRefreshMode(REFRESH_NONE)
     , intraRefreshCycleRestartIndex(0)
+    , intraRefreshSkippedStartIndex(0)
     , ycbcrModel(VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709)
     , ycbcrRange(VK_SAMPLER_YCBCR_RANGE_ITU_FULL)
     , components{VK_COMPONENT_SWIZZLE_IDENTITY,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -723,6 +723,13 @@ struct EncoderConfig : public VkVideoRefCountBase {
     enum { DEFAULT_NUM_SLICES_PER_PICTURE = 4 };
     enum { DEFAULT_MAX_NUM_REF_FRAMES = 16 };
     enum QpMapMode { DELTA_QP_MAP, EMPHASIS_MAP };
+    enum IntraRefreshMode {
+        REFRESH_NONE,
+        REFRESH_PER_PARTITION,
+        REFRESH_BLOCK_ROWS,
+        REFRESH_BLOCK_COLUMNS,
+        REFRESH_BLOCKS
+    };
 
     enum { ZERO_GOP_FRAME_COUNT = 0 };
     enum { ZERO_GOP_IDR_PERIOD  = 0 };
@@ -780,6 +787,11 @@ public:
 
     VkVideoGopStructure gopStructure;
     int8_t dpbCount;
+
+    // Parameters related to intra-refresh
+    bool enableIntraRefresh;
+    uint32_t intraRefreshCycleDuration;
+    IntraRefreshMode intraRefreshMode;
 
     // Vulkan Input color space and transfer characteristics parameters
     VkSamplerYcbcrModelConversion              ycbcrModel;
@@ -879,6 +891,9 @@ public:
                    CONSECUTIVE_B_FRAME_COUNT_MAX_VALUE,
                    DEFAULT_TEMPORAL_LAYER_COUNT)
     , dpbCount(8)
+    , enableIntraRefresh(false)
+    , intraRefreshCycleDuration(0)
+    , intraRefreshMode(REFRESH_NONE)
     , ycbcrModel(VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709)
     , ycbcrRange(VK_SAMPLER_YCBCR_RANGE_ITU_FULL)
     , components{VK_COMPONENT_SWIZZLE_IDENTITY,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -793,6 +793,7 @@ public:
     bool enableIntraRefresh;
     uint32_t intraRefreshCycleDuration;
     IntraRefreshMode intraRefreshMode;
+    uint32_t intraRefreshCycleRestartIndex;
 
     // Vulkan Input color space and transfer characteristics parameters
     VkSamplerYcbcrModelConversion              ycbcrModel;
@@ -896,6 +897,7 @@ public:
     , enableIntraRefresh(false)
     , intraRefreshCycleDuration(0)
     , intraRefreshMode(REFRESH_NONE)
+    , intraRefreshCycleRestartIndex(0)
     , ycbcrModel(VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709)
     , ycbcrRange(VK_SAMPLER_YCBCR_RANGE_ITU_FULL)
     , components{VK_COMPONENT_SWIZZLE_IDENTITY,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -1016,6 +1016,8 @@ public:
     virtual bool InitRateControl();
 
     virtual uint8_t GetMaxBFrameCount() { return 0;}
+
+    virtual bool IntraRefreshWithBFramesAllowed() { return false; }
 };
 
 // Create codec configuration for H.264 encoder

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -770,6 +770,7 @@ public:
     VkVideoCapabilitiesKHR videoCapabilities;
     VkVideoEncodeCapabilitiesKHR videoEncodeCapabilities;
     VkVideoEncodeQuantizationMapCapabilitiesKHR quantizationMapCapabilities;
+    VkVideoEncodeIntraRefreshCapabilitiesKHR intraRefreshCapabilities;
     VkVideoEncodeQualityLevelPropertiesKHR qualityLevelProperties;
     VkVideoEncodeRateControlModeFlagBitsKHR rateControlMode;
     uint32_t averageBitrate; // kbits/sec
@@ -875,6 +876,7 @@ public:
     , videoCapabilities()
     , videoEncodeCapabilities()
     , quantizationMapCapabilities()
+    , intraRefreshCapabilities()
     , rateControlMode(VK_VIDEO_ENCODE_RATE_CONTROL_MODE_FLAG_BITS_MAX_ENUM_KHR)
     , averageBitrate()
     , maxBitrate()

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
@@ -196,7 +196,8 @@ VkResult EncoderConfigAV1::InitDeviceCapabilities(const VulkanDeviceContext* vkD
                                                          videoEncodeCapabilities,
                                                          av1EncodeCapabilities,
                                                          quantizationMapCapabilities,
-                                                         av1QuantizationMapCapabilities);
+                                                         av1QuantizationMapCapabilities,
+                                                         intraRefreshCapabilities);
     if (result != VK_SUCCESS) {
         std::cout << "*** Could not get video capabilities :" << result << " ***" << std::endl;
         assert(!"Coult not get Video Capabilities!");

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
@@ -119,6 +119,11 @@ struct EncoderConfigAV1 : public EncoderConfig {
 
     virtual uint8_t GetMaxBFrameCount() override { return  static_cast<uint8_t>(av1EncodeCapabilities.maxBidirectionalCompoundReferenceCount); }
 
+    virtual bool IntraRefreshWithBFramesAllowed() override
+    {
+        return ((av1EncodeCapabilities.flags & VK_VIDEO_ENCODE_AV1_CAPABILITY_COMPOUND_PREDICTION_INTRA_REFRESH_BIT_KHR) != 0);
+    }
+
     bool GetRateControlParameters(VkVideoEncodeRateControlInfoKHR* rcInfo,
                                   VkVideoEncodeRateControlLayerInfoKHR* rcLayerInfo,
                                   VkVideoEncodeAV1RateControlInfoKHR* rcInfoAV1,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -360,7 +360,8 @@ VkResult EncoderConfigH264::InitDeviceCapabilities(const VulkanDeviceContext* vk
                                                                  videoEncodeCapabilities,
                                                                  h264EncodeCapabilities,
                                                                  quantizationMapCapabilities,
-                                                                 h264QuantizationMapCapabilities);
+                                                                 h264QuantizationMapCapabilities,
+                                                                 intraRefreshCapabilities);
     if (result != VK_SUCCESS) {
         std::cout << "*** Could not get Video Capabilities :" << result << " ***" << std::endl;
         assert(!"Could not get Video Capabilities!");

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -250,6 +250,17 @@ bool EncoderConfigH264::InitSpsPpsParameters(StdVideoH264SequenceParameterSet *s
     pps->num_ref_idx_l0_default_active_minus1 = numRefL0 > 0 ? numRefL0 - 1 : 0;
     pps->num_ref_idx_l1_default_active_minus1 = numRefL1 > 0 ? numRefL1 - 1 : 0;
 
+    if (enableIntraRefresh) {
+        uint8_t maxReferencePictures = std::min((uint8_t)intraRefreshCapabilities.maxIntraRefreshActiveReferencePictures,
+                                                (uint8_t)(pps->num_ref_idx_l0_default_active_minus1 + 1));
+
+        pps->num_ref_idx_l0_default_active_minus1 = maxReferencePictures - 1;
+
+        // TODO: Allow reference frames in reference list L1 if the implementation
+        // supports using B-frames in intra-refresh.
+        pps->num_ref_idx_l1_default_active_minus1 = 0;
+    }
+
     if ((sps->chroma_format_idc == 3) && !sps->flags.qpprime_y_zero_transform_bypass_flag) {
         pps->chroma_qp_index_offset = pps->second_chroma_qp_index_offset = 6;
     }

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -16,6 +16,25 @@
 
 #include "VkVideoEncoder/VkEncoderConfigH264.h"
 
+int EncoderConfigH264::DoParseArguments(int argc, const char* argv[])
+{
+    std::vector<std::string> args(argv, argv + argc);
+
+    for (int32_t i = 0; i < argc; i++) {
+        if (args[i] == "--slices") {
+            if (++i >= argc || sscanf(args[i].c_str(), "%u", &sliceCount) != 1) {
+                fprintf(stderr, "invalid parameter for %s\n", args[i - 1].c_str());
+                return -1;
+            }
+        } else {
+            fprintf(stderr, "Unrecognized option: %s\n", argv[i]);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
 StdVideoH264LevelIdc EncoderConfigH264::DetermineLevel(uint8_t dpbSize,
                                                        uint32_t bitrate,
                                                        uint32_t _vbvBufferSize,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -200,6 +200,11 @@ struct EncoderConfigH264 : public EncoderConfig {
         return static_cast<uint8_t>(h264EncodeCapabilities.maxBPictureL0ReferenceCount);
     }
 
+    virtual bool IntraRefreshWithBFramesAllowed() override
+    {
+        return ((h264EncodeCapabilities.flags & VK_VIDEO_ENCODE_H264_CAPABILITY_B_PICTURE_INTRA_REFRESH_BIT_KHR) != 0);
+    }
+
     bool GetRateControlParameters(VkVideoEncodeRateControlInfoKHR *rcInfo,
                                   VkVideoEncodeRateControlLayerInfoKHR *pRcLayerInfo,
                                   VkVideoEncodeH264RateControlInfoKHR *rcInfoH264,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -117,7 +117,7 @@ struct EncoderConfigH264 : public EncoderConfig {
 
     virtual ~EncoderConfigH264() {}
 
-    virtual EncoderConfigH264* GetEncoderConfigh264() {
+    virtual EncoderConfigH264* GetEncoderConfigh264() override {
         return this;
     }
 
@@ -162,7 +162,7 @@ struct EncoderConfigH264 : public EncoderConfig {
     static void SetAspectRatio(StdVideoH264SequenceParameterSetVui *vui, int32_t width, int32_t height,
                                int32_t darWidth, int32_t darHeight);
 
-    virtual VkResult InitializeParameters()
+    virtual VkResult InitializeParameters() override
     {
         VkResult result = EncoderConfig::InitializeParameters();
         if (result != VK_SUCCESS) {
@@ -181,17 +181,20 @@ struct EncoderConfigH264 : public EncoderConfig {
         return VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR;
     }
 
-    virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx);
+    virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx) override;
 
-    virtual uint32_t GetDefaultVideoProfileIdc() { return STD_VIDEO_H264_PROFILE_IDC_HIGH; };
+    virtual uint32_t GetDefaultVideoProfileIdc() override { return STD_VIDEO_H264_PROFILE_IDC_HIGH; };
 
     // 1. First h.264 determine the number of the Dpb buffers required
-    virtual int8_t InitDpbCount();
+    virtual int8_t InitDpbCount() override;
 
     // 2. First h.264 determine the rate control parameters
-    virtual bool InitRateControl();
+    virtual bool InitRateControl() override;
 
-    virtual uint8_t GetMaxBFrameCount() { return static_cast<uint8_t>(h264EncodeCapabilities.maxBPictureL0ReferenceCount); }
+    virtual uint8_t GetMaxBFrameCount() override
+    {
+        return static_cast<uint8_t>(h264EncodeCapabilities.maxBPictureL0ReferenceCount);
+    }
 
     bool GetRateControlParameters(VkVideoEncodeRateControlInfoKHR *rcInfo,
                                   VkVideoEncodeRateControlLayerInfoKHR *pRcLayerInfo,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -81,6 +81,7 @@ struct EncoderConfigH264 : public EncoderConfig {
         , rcLayerInfoH264{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_KHR }
         , rcInfo{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR, &rcInfoH264 }
         , rcLayerInfo{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR, &rcLayerInfoH264 }
+        , sliceCount(1)
         , disable_deblocking_filter_idc(STD_VIDEO_H264_DISABLE_DEBLOCKING_FILTER_IDC_DISABLED)
         , qpprime_y_zero_transform_bypass_flag(true)
         , constrained_intra_pred_flag(false)
@@ -145,6 +146,7 @@ struct EncoderConfigH264 : public EncoderConfig {
     VkVideoEncodeH264RateControlLayerInfoKHR   rcLayerInfoH264;
     VkVideoEncodeRateControlInfoKHR            rcInfo;
     VkVideoEncodeRateControlLayerInfoKHR       rcLayerInfo;
+    uint32_t                                   sliceCount;
 
     StdVideoH264DisableDeblockingFilterIdc     disable_deblocking_filter_idc;
 
@@ -153,6 +155,8 @@ struct EncoderConfigH264 : public EncoderConfig {
 
     const LevelLimits* levelLimits;
     size_t levelLimitsSize;
+
+    virtual int DoParseArguments(int argc, const char* argv[]) override;
 
     StdVideoH264LevelIdc DetermineLevel(uint8_t dpbSize,
                                         uint32_t bitrate,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -95,7 +95,8 @@ VkResult EncoderConfigH265::InitDeviceCapabilities(const VulkanDeviceContext* vk
                                                                  videoEncodeCapabilities,
                                                                  h265EncodeCapabilities,
                                                                  quantizationMapCapabilities,
-                                                                 h265QuantizationMapCapabilities);
+                                                                 h265QuantizationMapCapabilities,
+                                                                 intraRefreshCapabilities);
     if (result != VK_SUCCESS) {
         std::cout << "*** Could not get Video Capabilities :" << result << " ***" << std::endl;
         assert(!"Could not get Video Capabilities!");

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -67,6 +67,25 @@ uint32_t EncoderConfigH265::GetCpbVclFactor()
     return baseFactor + depthFactor;
 }
 
+int EncoderConfigH265::DoParseArguments(int argc, const char* argv[])
+{
+    std::vector<std::string> args(argv, argv + argc);
+
+    for (int32_t i = 0; i < argc; i++) {
+        if (args[i] == "--slices") {
+            if (++i >= argc || sscanf(args[i].c_str(), "%u", &sliceCount) != 1) {
+                fprintf(stderr, "invalid parameter for %s\n", args[i - 1].c_str());
+                return -1;
+            }
+        } else {
+            fprintf(stderr, "Unrecognized option: %s\n", argv[i]);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
 VkResult EncoderConfigH265::InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx)
 {
     VkResult result = VulkanVideoCapabilities::GetVideoEncodeCapabilities<VkVideoEncodeH265CapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_KHR,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -776,6 +776,18 @@ bool EncoderConfigH265::InitParamameters(VpsH265 *vpsInfo, SpsH265 *spsInfo,
     pps->num_extra_slice_header_bits = 0;
     pps->num_ref_idx_l0_default_active_minus1 = numRefL0 > 0 ? (uint8_t)(numRefL0 - 1) : 0;
     pps->num_ref_idx_l1_default_active_minus1 = numRefL1 > 0 ? (uint8_t)(numRefL1 - 1) : 0;
+
+    if (enableIntraRefresh) {
+        uint8_t maxReferencePictures = std::min((uint8_t)intraRefreshCapabilities.maxIntraRefreshActiveReferencePictures,
+                                                (uint8_t)(pps->num_ref_idx_l0_default_active_minus1 + 1));
+
+        pps->num_ref_idx_l0_default_active_minus1 = maxReferencePictures - 1;
+
+        // TODO: Allow reference frames in reference list L1 if the implementation
+        // supports using B-frames in intra-refresh.
+        pps->num_ref_idx_l1_default_active_minus1 = 0;
+    }
+
     pps->init_qp_minus26 = 0;
     pps->diff_cu_qp_delta_depth = 0;
     pps->pps_cb_qp_offset = 0;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
@@ -129,7 +129,7 @@ struct EncoderConfigH265 : public EncoderConfig {
 
     virtual ~EncoderConfigH265() {}
 
-    virtual EncoderConfigH265* GetEncoderConfigh265() {
+    virtual EncoderConfigH265* GetEncoderConfigh265() override {
         return this;
     }
 
@@ -137,7 +137,7 @@ struct EncoderConfigH265 : public EncoderConfig {
 
     uint32_t GetCpbVclFactor();
 
-    virtual VkResult InitializeParameters()
+    virtual VkResult InitializeParameters() override
     {
         VkResult result = EncoderConfig::InitializeParameters();
         if (result != VK_SUCCESS) {
@@ -147,20 +147,23 @@ struct EncoderConfigH265 : public EncoderConfig {
         return VK_SUCCESS;
     }
 
-    virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx);
+    virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx) override;
 
-    virtual uint32_t GetDefaultVideoProfileIdc() { return STD_VIDEO_H265_PROFILE_IDC_MAIN; };
+    virtual uint32_t GetDefaultVideoProfileIdc() override { return STD_VIDEO_H265_PROFILE_IDC_MAIN; };
 
     // 1. First h.265 determine the number of the Dpb buffers required
-    virtual int8_t InitDpbCount();
+    virtual int8_t InitDpbCount() override;
 
     uint32_t GetMaxDpbSize(uint32_t pictureSizeInSamplesY, int32_t levelIndex);
     int8_t VerifyDpbSize();
 
     // 2. First h.265 determine the rate control parameters
-    virtual bool InitRateControl();
+    virtual bool InitRateControl() override;
 
-    virtual uint8_t GetMaxBFrameCount() { return  static_cast<uint8_t>(h265EncodeCapabilities.maxBPictureL0ReferenceCount); }
+    virtual uint8_t GetMaxBFrameCount() override
+    {
+        return static_cast<uint8_t>(h265EncodeCapabilities.maxBPictureL0ReferenceCount);
+    }
 
     bool GetRateControlParameters(VkVideoEncodeRateControlInfoKHR *rcInfo,
                                   VkVideoEncodeRateControlLayerInfoKHR *pRcLayerInfo,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
@@ -169,6 +169,11 @@ struct EncoderConfigH265 : public EncoderConfig {
         return static_cast<uint8_t>(h265EncodeCapabilities.maxBPictureL0ReferenceCount);
     }
 
+    virtual bool IntraRefreshWithBFramesAllowed() override
+    {
+        return ((h265EncodeCapabilities.flags & VK_VIDEO_ENCODE_H265_CAPABILITY_B_PICTURE_INTRA_REFRESH_BIT_KHR) != 0);
+    }
+
     bool GetRateControlParameters(VkVideoEncodeRateControlInfoKHR *rcInfo,
                                   VkVideoEncodeRateControlLayerInfoKHR *pRcLayerInfo,
                                   VkVideoEncodeH265RateControlInfoKHR *rcInfoH265,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
@@ -78,6 +78,7 @@ struct EncoderConfigH265 : public EncoderConfig {
     uint32_t               vbvInitialDelay;       // Specifies the VBV(HRD) initial delay in bits. Set 0 to use the default VBV  initial delay.
     VkVideoEncodeH265QpKHR minQp;                 // Specifies the const or minimum or QP used for rate control.
     VkVideoEncodeH265QpKHR maxQp;                 // Specifies the maximum QP used for rate control.
+    uint32_t               sliceCount;
     const LevelLimits*     levelLimits;
     size_t                 levelLimitsTblSize;
 
@@ -99,6 +100,7 @@ struct EncoderConfigH265 : public EncoderConfig {
       , vbvInitialDelay()
       , minQp{}
       , maxQp{}
+      , sliceCount(1)
     {
         // Table A-1
         static const LevelLimits levelLimitsTbl[] = {
@@ -132,6 +134,8 @@ struct EncoderConfigH265 : public EncoderConfig {
     virtual EncoderConfigH265* GetEncoderConfigh265() override {
         return this;
     }
+
+    virtual int DoParseArguments(int argc, const char* argv[]) override;
 
     uint32_t GetCtbAlignedPicSizeInSamples(uint32_t& picWidthInCtbsY, uint32_t& picHeightInCtbsY, bool minCtbsY = false);
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.cpp
@@ -151,6 +151,16 @@ int32_t VkEncDpbAV1::DpbSequenceStart(const VkVideoEncodeAV1CapabilitiesKHR& cap
     } else {
         m_maxRefFramesL1 = 3; // 0
     }
+
+    if (encoderConfig->enableIntraRefresh) {
+        const VkVideoEncodeIntraRefreshCapabilitiesKHR& intraRefreshCaps = encoderConfig->intraRefreshCapabilities;
+
+        m_maxRefFramesL0 = std::min(m_maxRefFramesL0, (int32_t)intraRefreshCaps.maxIntraRefreshActiveReferencePictures);
+
+        // TODO: check for compound prediction being allowed with intra-refresh
+        m_maxRefFramesL1 = 0;
+    }
+
     // Restricts the number of references in Group1 and Group2
     m_maxRefFramesGroup1 = 4;
     if (numBFrames > 0) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.cpp
@@ -28,7 +28,6 @@
 #include <stdint.h>
 
 #include "VkEncoderDpbAV1.h"
-#include "VkEncoderConfigAV1.h"
 
 #define VK_DPB_DBG_PRINT(expr) printf expr
 
@@ -125,9 +124,11 @@ void VkEncDpbAV1::DpbDestroy()
     delete this;
 }
 
-int32_t VkEncDpbAV1::DpbSequenceStart(const VkVideoEncodeAV1CapabilitiesKHR& capabilities, uint32_t userDpbSize, int32_t numBFrames,
-                                      VkVideoEncodeTuningModeKHR tuningMode, uint32_t qualityLevel)
+int32_t VkEncDpbAV1::DpbSequenceStart(const VkSharedBaseObj<EncoderConfigAV1>& encoderConfig, uint32_t userDpbSize)
 {
+    const VkVideoEncodeAV1CapabilitiesKHR& capabilities = encoderConfig->av1EncodeCapabilities;
+    int32_t numBFrames = encoderConfig->gopStructure.GetConsecutiveBFrameCount();
+
     DpbDeinit();
 
     assert(userDpbSize <= BUFFER_POOL_MAX_SIZE);

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.cpp
@@ -848,3 +848,18 @@ void VkEncDpbAV1::FillStdReferenceInfo(uint8_t dpbIdx, StdVideoEncodeAV1Referenc
     pStdReferenceInfo->frame_type = pDpbEntry->frameType;
     pStdReferenceInfo->OrderHint = pDpbEntry->picOrderCntVal % (1 << ORDER_HINT_BITS);
 }
+
+uint32_t VkEncDpbAV1::GetDirtyIntraRefreshRegions(int8_t dpbIdx)
+{
+    assert(dpbIdx < m_maxDpbSize);
+    const DpbEntryAV1* pDpbEntry = &m_DPB[dpbIdx];
+
+    return pDpbEntry->dirtyIntraRefreshRegions;
+}
+
+void VkEncDpbAV1::SetDirtyIntraRefreshRegions(int8_t dpbIdx, uint32_t dirtyIntraRefreshRegions)
+{
+    assert(dpbIdx < m_maxDpbSize);
+
+    m_DPB[dpbIdx].dirtyIntraRefreshRegions = dirtyIntraRefreshRegions;
+}

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.h
@@ -55,6 +55,9 @@ struct DpbEntryAV1 {
 
     // The YCbCr dpb image resource
     VkSharedBaseObj<VulkanVideoImagePoolNode>  dpbImageView;
+
+    // Intra-refresh information
+    uint32_t dirtyIntraRefreshRegions;
 };
 
 struct PicInfoAV1 : public StdVideoEncodeAV1PictureInfo {
@@ -134,6 +137,9 @@ public:
     }
     uint64_t GetPictureTimestamp(int32_t picIdx);
     void SetCurRefFrameTimeStamp(uint64_t timeStamp);
+
+    uint32_t GetDirtyIntraRefreshRegions(int8_t dpbIdx);
+    void SetDirtyIntraRefreshRegions(int8_t dpbIdx, uint32_t dirtyIntraRefreshRegions);
 
     void FillStdReferenceInfo(uint8_t dpbIdx, StdVideoEncodeAV1ReferenceInfo* pStdReferenceInfo);
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.h
@@ -20,6 +20,7 @@
 #include "VkVideoEncoderDef.h"
 #include "VkCodecUtils/VulkanVideoImagePool.h"
 #include "VkVideoEncoder/VkVideoGopStructure.h"
+#include "VkEncoderConfigAV1.h"
 
 enum VkVideoEncoderAV1PrimaryRefType {
     REGULAR_FRAME   = 0,        // regular inter frame
@@ -112,8 +113,7 @@ public:
     // 1. Init instance
     static VkEncDpbAV1 *CreateInstance(void);
     // 2. Init encode session
-    int32_t DpbSequenceStart(const VkVideoEncodeAV1CapabilitiesKHR& capabilities, uint32_t userDpbSize, int32_t numBFrames,
-                             VkVideoEncodeTuningModeKHR tuningMode, uint32_t qualityLevel);
+    int32_t DpbSequenceStart(const VkSharedBaseObj<EncoderConfigAV1>& encoderConfig, uint32_t userDpbSize = 0);
     // 3. Start Picture - returns the allocated DPB index for this frame
     int8_t DpbPictureStart(StdVideoAV1FrameType frameType,
                            StdVideoAV1ReferenceName refName,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.cpp
@@ -1639,6 +1639,19 @@ void VkEncDpbH264::SetCurRefFrameTimeStamp(uint64_t refFrameTimeStamp)
     m_DPB[m_currDpbIdx].refFrameTimeStamp = refFrameTimeStamp;
 }
 
+uint32_t VkEncDpbH264::GetDirtyIntraRefreshRegions(int32_t dpb_idx)
+{
+    if ((dpb_idx >= 0) && (dpb_idx < MAX_DPB_SLOTS) && (m_DPB[dpb_idx].state != DPB_EMPTY)) {
+        return (m_DPB[dpb_idx].dirtyIntraRefreshRegions);
+    }
+    return 0;
+}
+
+void VkEncDpbH264::SetCurDirtyIntraRefreshRegions(uint32_t dirtyIntraRefreshRegions)
+{
+    m_DPB[m_currDpbIdx].dirtyIntraRefreshRegions = dirtyIntraRefreshRegions;
+}
+
 // Returns a "view" of the DPB in terms of the entries holding valid reference
 // pictures.
 int32_t VkEncDpbH264::GetValidEntries(DpbEntryH264 entries[MAX_DPB_SLOTS])

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.h
@@ -59,6 +59,9 @@ struct DpbEntryH264 {
 
     uint64_t timeStamp;
     uint64_t refFrameTimeStamp;
+
+    // Intra-refresh
+    uint32_t dirtyIntraRefreshRegions;
 };
 
 struct PicInfoH264 : public StdVideoEncodeH264PictureInfo {
@@ -129,6 +132,9 @@ public:
     int32_t GetPicNumFromDpbIdx(int32_t dpbIdx, bool *shortterm, bool *longterm);
     uint64_t GetPictureTimestamp(int32_t picIdx);
     void SetCurRefFrameTimeStamp(uint64_t timeStamp);
+
+    uint32_t GetDirtyIntraRefreshRegions(int32_t dpbIdx);
+    void SetCurDirtyIntraRefreshRegions(uint32_t dirtyIntraRefreshRegions);
 
     const StdVideoEncodeH264PictureInfo *GetCurrentDpbEntry(void)
     {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH265.cpp
@@ -926,3 +926,16 @@ void VkEncDpbH265::InitializeRPS(const StdVideoH265ShortTermRefPicSet *pSpsShort
     InitializeShortTermRPSPFrame(numPocLtCurr, pSpsShortTermRps, spsNumShortTermRefPicSets,
                                  pPicInfo, pShortTermRefPicSet, numRefL0, numRefL1);
 }
+
+uint32_t VkEncDpbH265::GetDirtyIntraRefreshRegions(int32_t dpb_idx)
+{
+    if ((dpb_idx >= 0) && (dpb_idx < STD_VIDEO_H265_MAX_DPB_SIZE) && (m_stDpb[dpb_idx].state != 0)) {
+        return (m_stDpb[dpb_idx].dirtyIntraRefreshRegions);
+    }
+    return 0;
+}
+
+void VkEncDpbH265::SetCurDirtyIntraRefreshRegions(uint32_t dirtyIntraRefreshRegions)
+{
+    m_stDpb[m_curDpbIndex].dirtyIntraRefreshRegions = dirtyIntraRefreshRegions;
+}

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH265.h
@@ -35,6 +35,9 @@ struct DpbEntryH265 {
     VkSharedBaseObj<VulkanVideoImagePoolNode>  dpbImageView;
     uint64_t frameId;      // internal unique id
     int32_t  temporalId;
+
+    // Intra-refresh
+    uint32_t dirtyIntraRefreshRegions;
 };
 
 class VkEncDpbH265 {
@@ -84,6 +87,9 @@ public:
     void FillStdReferenceInfo(uint8_t dpbIndex, StdVideoEncodeH265ReferenceInfo *pRefInfo);
 
     void ReferencePictureListIntializationLx(int32_t refPicListLx[2][STD_VIDEO_H265_MAX_NUM_LIST_REF], int32_t refPicListSize[2], const StdVideoEncodeH265SliceSegmentHeader *slh);
+
+    uint32_t GetDirtyIntraRefreshRegions(int32_t dpbIdx);
+    void SetCurDirtyIntraRefreshRegions(uint32_t dirtyIntraRefreshRegions);
 
 private:
     void FlushDpb();

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -882,6 +882,7 @@ VkResult VkVideoEncoder::InitEncoder(VkSharedBaseObj<EncoderConfig>& encoderConf
                                              m_imageDpbFormat,
                                              maxDpbPicturesCount,
                                              maxActiveReferencePicturesCount,
+                                             nullptr,
                                              m_videoSession);
 
         // after creating a new video session, we need a codec reset.

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -1621,6 +1621,18 @@ void VkVideoEncoder::ProcessQpMap(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encod
     vk::ChainNextVkStruct(encodeFrameInfo->encodeInfo, encodeFrameInfo->quantizationMapInfo);
 }
 
+void VkVideoEncoder::FillIntraRefreshInfo(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo)
+{
+    encodeFrameInfo->intraRefreshInfo.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_INTRA_REFRESH_INFO_KHR;
+    encodeFrameInfo->intraRefreshInfo.pNext = nullptr;
+    encodeFrameInfo->intraRefreshInfo.intraRefreshCycleDuration = m_encoderConfig->intraRefreshCycleDuration;
+    encodeFrameInfo->intraRefreshInfo.intraRefreshIndex = encodeFrameInfo->gopPosition.intraRefreshIndex;
+
+    encodeFrameInfo->encodeInfo.flags |= VK_VIDEO_ENCODE_INTRA_REFRESH_BIT_KHR;
+
+    vk::ChainNextVkStruct(encodeFrameInfo->encodeInfo, encodeFrameInfo->intraRefreshInfo);
+}
+
 VkResult VkVideoEncoder::HandleCtrlCmd(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo)
 {
     m_sendControlCmd = false;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -792,6 +792,19 @@ VkResult VkVideoEncoder::InitEncoder(VkSharedBaseObj<EncoderConfig>& encoderConf
         }
         m_encoderConfig->gopStructure.SetConsecutiveBFrameCount(encoderConfig->GetMaxBFrameCount());
     }
+
+    if (m_encoderConfig->enableIntraRefresh) {
+        if (!m_encoderConfig->IntraRefreshWithBFramesAllowed() &&
+            (m_encoderConfig->gopStructure.GetConsecutiveBFrameCount() != 0)) {
+
+            if (m_encoderConfig->verbose) {
+                std::cout << "Use of B-frames / compound prediction is not supported when intra-refresh is enabled" << std::endl;
+                std::cout << "Setting the count of Consecutive B-frames to 0" << std::endl;
+            }
+            m_encoderConfig->gopStructure.SetConsecutiveBFrameCount(0);
+        }
+    }
+
     if (m_encoderConfig->verbose) {
         std::cout << std::endl << "GOP frame count: " << (uint32_t)m_encoderConfig->gopStructure.GetGopFrameCount();
         std::cout << ", IDR period: " << (uint32_t)m_encoderConfig->gopStructure.GetIdrPeriod();

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
@@ -64,6 +64,7 @@ public:
                                VkVideoCodecOperationFlagBitsKHR codec = VK_VIDEO_CODEC_OPERATION_NONE_KHR)
             : encodeInfo{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR, pNext}
             , quantizationMapInfo()
+            , intraRefreshInfo()
             , frameInputOrderNum(uint64_t(-1))
             , frameEncodeInputOrderNum(uint64_t(-1))
             , frameEncodeEncodeOrderNum(uint64_t(-1))
@@ -117,6 +118,7 @@ public:
 
         VkVideoEncodeInfoKHR                               encodeInfo;
         VkVideoEncodeQuantizationMapInfoKHR                quantizationMapInfo;
+        VkVideoEncodeIntraRefreshInfoKHR                   intraRefreshInfo;
         uint64_t                                           frameInputOrderNum;          // == encoder input order in sequence
         uint64_t                                           frameEncodeInputOrderNum;    // == encoder input order sequence number
         uint64_t                                           frameEncodeEncodeOrderNum;   // == encoder encode order sequence number
@@ -608,6 +610,8 @@ protected:
                                      VkImageLayout dstImageLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     void ProcessQpMap(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
+
+    void FillIntraRefreshInfo(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
 
     virtual VkResult ProcessDpb(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo,
                                 uint32_t frameIdx, uint32_t ofTotalFrames) = 0;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
@@ -89,6 +89,7 @@ public:
             , rateControlInfo { VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR }
             , rateControlLayersInfo{{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR }}
             , referenceSlotsInfo{}
+            , referenceIntraRefreshInfo{}
             , setupReferenceSlotInfo{ VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR }
             , videoSession()
             , videoSessionParameters()
@@ -108,6 +109,10 @@ public:
             assert(ARRAYSIZE(referenceSlotsInfo) == MAX_IMAGE_REF_RESOURCES);
             for (uint32_t i = 0; i < MAX_IMAGE_REF_RESOURCES; i++) {
                 referenceSlotsInfo[i].sType = VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR;
+            }
+            for (uint32_t i = 0; i < MAX_IMAGE_REF_RESOURCES; i++) {
+                referenceIntraRefreshInfo[i].sType = VK_STRUCTURE_TYPE_VIDEO_REFERENCE_INTRA_REFRESH_INFO_KHR;
+                referenceIntraRefreshInfo[i].pNext = nullptr;
             }
             assert(numDpbImageResources <= ARRAYSIZE(dpbImageResources));
             for (uint32_t i = 0; i < numDpbImageResources; i++) {
@@ -143,6 +148,7 @@ public:
         VkVideoEncodeRateControlInfoKHR                    rateControlInfo;
         VkVideoEncodeRateControlLayerInfoKHR               rateControlLayersInfo[1];
         VkVideoReferenceSlotInfoKHR                        referenceSlotsInfo[MAX_IMAGE_REF_RESOURCES];
+        VkVideoReferenceIntraRefreshInfoKHR                referenceIntraRefreshInfo[MAX_IMAGE_REF_RESOURCES];
         VkVideoReferenceSlotInfoKHR                        setupReferenceSlotInfo;
         VkSharedBaseObj<VulkanVideoSession>                videoSession;
         VkSharedBaseObj<VulkanVideoSessionParameters>      videoSessionParameters;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
@@ -100,8 +100,7 @@ VkResult VkVideoEncoderAV1::InitEncoderCodec(VkSharedBaseObj<EncoderConfig>& enc
     // Initialize DPB
     m_dpbAV1 = VkEncDpbAV1::CreateInstance();
     assert(m_dpbAV1);
-    m_dpbAV1->DpbSequenceStart(encodeCaps, m_maxDpbPicturesCount, encoderConfig->gopStructure.GetConsecutiveBFrameCount(),
-                               encoderConfig->tuningMode, encoderConfig->qualityLevel);
+    m_dpbAV1->DpbSequenceStart(m_encoderConfig, m_maxDpbPicturesCount);
 
     m_encoderConfig->GetRateControlParameters(&m_rateControlInfo, m_rateControlLayersInfo, &m_stateAV1.m_rateControlInfoAV1, m_stateAV1.m_rateControlLayersInfoAV1);
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
@@ -556,6 +556,11 @@ VkResult VkVideoEncoderAV1::EncodeFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>&
         ProcessQpMap(encodeFrameInfo);
     }
 
+    const bool isIntraRefreshFrame = m_encoderConfig->gopStructure.IsIntraRefreshFrame(encodeFrameInfo->gopPosition);
+    if (m_encoderConfig->enableIntraRefresh && isIntraRefreshFrame) {
+        FillIntraRefreshInfo(encodeFrameInfo);
+    }
+
     EnqueueFrame(encodeFrameInfo, pFrameInfo->bIsKeyFrame, pFrameInfo->bIsReference);
 
     return VK_SUCCESS;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.h
@@ -33,9 +33,9 @@ public:
     struct VkVideoEncodeFrameInfoH264 : public VkVideoEncodeFrameInfo {
 
         VkVideoEncodeH264PictureInfoKHR          pictureInfo;
-        VkVideoEncodeH264NaluSliceInfoKHR        naluSliceInfo;
+        VkVideoEncodeH264NaluSliceInfoKHR        naluSliceInfo[MAX_NUM_SLICES_H264];
         StdVideoEncodeH264PictureInfo            stdPictureInfo;
-        StdVideoEncodeH264SliceHeader            stdSliceHeader;
+        StdVideoEncodeH264SliceHeader            stdSliceHeader[MAX_NUM_SLICES_H264];
         VkVideoEncodeH264RateControlInfoKHR      rateControlInfoH264;
         VkVideoEncodeH264RateControlLayerInfoKHR rateControlLayersInfoH264[1];
         StdVideoEncodeH264ReferenceListsInfo     stdReferenceListsInfo;
@@ -48,9 +48,9 @@ public:
         VkVideoEncodeFrameInfoH264()
           : VkVideoEncodeFrameInfo(&pictureInfo, VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR)
           , pictureInfo { VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_KHR }
-          , naluSliceInfo { VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_KHR }
+          , naluSliceInfo{}
           , stdPictureInfo()
-          , stdSliceHeader()
+          , stdSliceHeader{}
           , rateControlInfoH264{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_INFO_KHR }
           , rateControlLayersInfoH264 {{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_KHR }}
           , stdReferenceListsInfo()
@@ -61,9 +61,16 @@ public:
           , refPicMarkingEntry{}
         {
             pictureInfo.naluSliceEntryCount = 1; // FIXME: support more than one
-            pictureInfo.pNaluSliceEntries = &naluSliceInfo;
+            pictureInfo.pNaluSliceEntries = naluSliceInfo;
             pictureInfo.pStdPictureInfo = &stdPictureInfo;
-            naluSliceInfo.pStdSliceHeader = &stdSliceHeader;
+
+            for (uint32_t i = 0; i < MAX_NUM_SLICES_H264; i++) {
+                auto& sliceInfo = naluSliceInfo[i];
+
+                sliceInfo.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_KHR;
+                sliceInfo.pNext = nullptr;
+                sliceInfo.pStdSliceHeader = &stdSliceHeader[i];
+            }
 
             stdPictureInfo.pRefLists           = &stdReferenceListsInfo;
 
@@ -83,7 +90,7 @@ public:
 
             // Clear and check state
             assert(pictureInfo.sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_KHR);
-            assert(naluSliceInfo.sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_KHR);
+            assert(naluSliceInfo[0].sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_KHR);
             // stdPictureInfo()
             // stdSliceHeader()
             assert(rateControlInfoH264.sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_INFO_KHR);

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.cpp
@@ -238,6 +238,10 @@ VkResult VkVideoEncoderH265::ProcessDpb(VkSharedBaseObj<VkVideoEncodeFrameInfo>&
 
     const bool isIntraRefreshFrame = m_encoderConfig->gopStructure.IsIntraRefreshFrame(encodeFrameInfo->gopPosition);
     if (m_encoderConfig->enableIntraRefresh && isIntraRefreshFrame) {
+        // The number of dirty intra-refresh regions in the current picture
+        uint32_t dirtyIntraRefreshRegions = m_encoderConfig->intraRefreshCycleDuration - encodeFrameInfo->gopPosition.intraRefreshIndex - 1;
+
+        m_dpb.SetCurDirtyIntraRefreshRegions(dirtyIntraRefreshRegions);
 
         if (m_encoderConfig->intraRefreshMode == EncoderConfig::REFRESH_PER_PARTITION) {
             // When using per-picture partition intra-refresh, mark the slice corresponding
@@ -268,6 +272,14 @@ VkResult VkVideoEncoderH265::ProcessDpb(VkSharedBaseObj<VkVideoEncodeFrameInfo>&
 
             pFrameInfo->stdDpbSlotInfo[numReferenceSlots].sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_DPB_SLOT_INFO_KHR;
             pFrameInfo->stdDpbSlotInfo[numReferenceSlots].pStdReferenceInfo = &pFrameInfo->stdReferenceInfo[numReferenceSlots];
+
+            if (isIntraRefreshFrame) {
+                pFrameInfo->referenceIntraRefreshInfo[numReferenceSlots].sType = VK_STRUCTURE_TYPE_VIDEO_REFERENCE_INTRA_REFRESH_INFO_KHR;
+                pFrameInfo->referenceIntraRefreshInfo[numReferenceSlots].dirtyIntraRefreshRegions =
+                    m_dpb.GetDirtyIntraRefreshRegions(dpbIndex);
+
+                pFrameInfo->stdDpbSlotInfo[numReferenceSlots].pNext = &pFrameInfo->referenceIntraRefreshInfo[numReferenceSlots];
+            }
 
             pFrameInfo->referenceSlotsInfo[numReferenceSlots].sType = VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR;
             pFrameInfo->referenceSlotsInfo[numReferenceSlots].pNext = &pFrameInfo->stdDpbSlotInfo[numReferenceSlots];

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.cpp
@@ -34,6 +34,7 @@ VkVideoGopStructure::VkVideoGopStructure(uint8_t gopFrameCount,
     , m_closedGop(closedGop)
     , m_intraRefreshCycleDuration(intraRefreshCycleDuration)
     , m_intraRefreshCycleRestartIndex(0)
+    , m_intraRefreshSkippedStartIndex(0)
 {
     Init(uint64_t(-1));
 }

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.cpp
@@ -22,7 +22,8 @@ VkVideoGopStructure::VkVideoGopStructure(uint8_t gopFrameCount,
                                          uint8_t temporalLayerCount,
                                          FrameType lastFrameType,
                                          FrameType preIdrAnchorFrameType,
-                                         bool closedGop)
+                                         bool closedGop,
+                                         uint32_t intraRefreshCycleDuration)
     : m_gopFrameCount(gopFrameCount)
     , m_consecutiveBFrameCount(consecutiveBFrameCount)
     , m_gopFrameCycle((uint8_t)(m_consecutiveBFrameCount + 1))
@@ -31,6 +32,7 @@ VkVideoGopStructure::VkVideoGopStructure(uint8_t gopFrameCount,
     , m_lastFrameType(lastFrameType)
     , m_preClosedGopAnchorFrameType(preIdrAnchorFrameType)
     , m_closedGop(closedGop)
+    , m_intraRefreshCycleDuration(intraRefreshCycleDuration)
 {
     Init(uint64_t(-1));
 }

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoGopStructure.cpp
@@ -33,6 +33,7 @@ VkVideoGopStructure::VkVideoGopStructure(uint8_t gopFrameCount,
     , m_preClosedGopAnchorFrameType(preIdrAnchorFrameType)
     , m_closedGop(closedGop)
     , m_intraRefreshCycleDuration(intraRefreshCycleDuration)
+    , m_intraRefreshCycleRestartIndex(0)
 {
     Init(uint64_t(-1));
 }


### PR DESCRIPTION
This set of changes adds support in the encoder sample application for the [VK_KHR_video_encode_intra_refresh](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_encode_intra_refresh.html) extension.