### PR TITLE
encode: check QP map file size against number of frames being encoded

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -606,6 +606,19 @@ public:
         return m_memMapedFile.data() + fileOffset;
     }
 
+    uint32_t GetFrameCount(uint32_t width, uint32_t height, const VkExtent2D& qpMapTexelSize)
+    {
+        uint32_t widthQpMapTexels  = (width  + qpMapTexelSize.width  - 1) / qpMapTexelSize.width;
+        uint32_t heightQpMapTexels = (height + qpMapTexelSize.height - 1) / qpMapTexelSize.height;
+
+        uint32_t frameSize = widthQpMapTexels * heightQpMapTexels;
+
+        if (frameSize)
+            return (uint32_t)(GetFileSize() / frameSize);
+
+        return 0;
+    }
+
 private:
     size_t OpenFile()
     {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -827,6 +827,16 @@ VkResult VkVideoEncoder::InitEncoder(VkSharedBaseObj<EncoderConfig>& encoderConf
         m_imageQpMapFormat = supportedQpMapFormats[0];
         m_qpMapTexelSize = supportedQpMapTexelSize[0];
         m_qpMapTiling = supportedQpMapTiling[0];
+
+        uint32_t qpMapFrameCount = encoderConfig->qpMapFileHandler.GetFrameCount(encoderConfig->input.width,
+                                                                                 encoderConfig->input.height,
+                                                                                 m_qpMapTexelSize);
+        if (qpMapFrameCount < encoderConfig->numFrames) {
+            std::cerr << "Number of QP maps (" << qpMapFrameCount << ") in the input QP map file "
+                      << "is less than the number of frames (" << encoderConfig->numFrames
+                      << ") to be encoded." << std::endl;
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
     }
 
     encoderConfig->encodeWidth  = std::max(encoderConfig->encodeWidth,  encoderConfig->videoCapabilities.minCodedExtent.width);


### PR DESCRIPTION
The file processing code expects a QP map to be available for each frame being encoded but does not check that this is actually the cause. Specifying a QP map file with an insufficient number of QP maps can cause a segmentation fault / access violation.

This change adds the method EncoderQpMapFileHandler::GetFrameCount() to allow checking that the QP map file has a sufficient number of QP maps.