### PR TITLE
Partly revert commit 16607fe (changes for m_beginRateControlInfo)

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -1774,8 +1774,7 @@ VkResult VkVideoEncoder::RecordVideoCodingCmd(VkSharedBaseObj<VkVideoEncodeFrame
         vkDevCtx->CmdControlVideoCodingKHR(cmdBuf, &renderControlInfo);
 
         m_beginRateControlInfo = *(VkVideoEncodeRateControlInfoKHR*)encodeFrameInfo->pControlCmdChain;
-        // Do not walk the chain, otherwise we end up creating a loop here.
-        m_beginRateControlInfo.pNext = (VkBaseInStructure*)(&encodeFrameInfo->pControlCmdChain);
+        const_cast<VkBaseInStructure*>(static_cast<const VkBaseInStructure*>(m_beginRateControlInfo.pNext))->pNext = NULL;
     }
 
     if (m_videoMaintenance1FeaturesSupported)


### PR DESCRIPTION
We assign two times the same structure to the m_beginRateControlInfo and m_beginRateControlInfo->pNext.
Also removing ((VkBaseInStructure*)(m_beginRateControlInfo.pNext))->pNext = NULL; leads to the VL error:

The introduced change as above leads to the following errors:

```
./vk_video_encoder/demos/vk-video-enc-test --enableHwLoadBalancing --inputWidth 1920 --inputHeight 1080 --tuningMode lowlatency --averageBitrate 40000000 --maxBitrate 60000000 --codec hevc --qualityLevel 1 --rateControlMode vbr --gopFrameCount -1 --idrPeriod -1 --consecutiveBFrameCount 0 --inputNumPlanes 3 --startFrame 0 --numFrames 100 -i <your_yuv>

// When removing = NULL assignment:
VUID-VkVideoBeginCodingInfoKHR-pNext-pNext(ERROR / SPEC): msgNum: -1966186255 - Validation Error: [ VUID-VkVideoBeginCodingInfoKHR-pNext-pNext ] | MessageID = 0x8ace60f1 | vkCmdBeginVideoCodingKHR(): pBeginInfo->pNext chain includes a structure with unexpected VkStructureType VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR.
// When assigning two times:
VUID-VkVideoBeginCodingInfoKHR-pNext-pNext(ERROR / SPEC): msgNum: -1966186255 - Validation Error: [ VUID-VkVideoBeginCodingInfoKHR-pNext-pNext ] | MessageID = 0x8ace60f1 | vkCmdBeginVideoCodingKHR(): pBeginInfo->pNext chain includes a structure with unexpected VkStructureType VK_STRUCTURE_TYPE_APPLICATION_INFO.

Segmentation fault (core dumped)
```

Also fixed warning which was before the reverted commit: cast from type ‘const void*’ to type ‘VkBaseInStructure*’ casts away qualifiers [-Wcast-qual]