### PR TITLE
encode: Set the MSB shift for 10/12-bit input

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -1009,6 +1009,27 @@ public:
             return VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR;
         }
 
+        // Deal with the input shift values, if not explicitly set.
+        if (input.msbShift == -1) {
+
+            if (input.bpp > 8) {
+
+                // Only apply the shift for higher bit-depth formats (10/12-bit)
+                assert ((input.bpp == 10) || (input.bpp == 12));
+
+                // Calculate shift amount based on bit depth
+                // We shift the content to the MSB of the word if it is a 16-bit container
+                input.msbShift = 16 - input.bpp;
+
+                assert ((input.msbShift == 6) || (input.msbShift == 4));
+
+            } else {
+
+                input.msbShift = 0;
+
+            }
+        }
+
         // Copy chroma subsampling from input to encoder config
         encodeChromaSubsampling = input.chromaSubsampling;
 


### PR DESCRIPTION
Set automatically the input.msbShift value to the default shift, if not explicitly set by the API for 10/12-bit input.