### PR TITLE
Update DPB after populating reference slot infos

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.cpp
@@ -122,7 +122,6 @@ void VkEncDpbH264::DpbInit()
 void VkEncDpbH264::DpbDeinit()
 {
     m_max_dpb_size = 0;
-    m_currDpbIdx = 0;
     m_lastIDRTimeStamp = 0;
     m_currDpbIdx = -1;
 };
@@ -246,15 +245,8 @@ int8_t VkEncDpbH264::DpbPictureEnd(const PicInfoH264 *pPicInfo,
         for (int32_t i = 0; i < MAX_DPB_SLOTS; i++) {
             m_DPB[i].top_field_marking = MARKING_UNUSED;
             m_DPB[i].bottom_field_marking = MARKING_UNUSED;
-            m_DPB[i].state = MARKING_UNUSED;
+            m_DPB[i].state = DPB_EMPTY;
             ReleaseFrame(m_DPB[i].dpbImageView);
-        }
-        // TODO: infer no_output_of_prior_pics_flag if size has changed etc.
-        if (pPicInfo->flags.no_output_of_prior_pics_flag) {
-            for (int32_t i = 0; i < MAX_DPB_SLOTS; i++) {
-                m_DPB[i].state = DPB_EMPTY;  // empty
-                ReleaseFrame(m_DPB[i].dpbImageView);
-            }
         }
     }
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.h
@@ -130,7 +130,7 @@ public:
     bool IsRefFramesCorrupted();
     bool IsRefPicCorrupted(int32_t picIndex);
     int32_t GetPicNumFromDpbIdx(int32_t dpbIdx, bool *shortterm, bool *longterm);
-    uint64_t GetPictureTimestamp(int32_t picIdx);
+    uint64_t GetPictureTimestamp(int32_t dpbIdx);
     void SetCurRefFrameTimeStamp(uint64_t timeStamp);
 
     uint32_t GetDirtyIntraRefreshRegions(int32_t dpbIdx);


### PR DESCRIPTION
Populating reference slot details for encode after DPB management and picture marking sometime result into incorrect details.   This includes incorrect picture, poc and other values related to the reference picture.  So, populate all the details before DPB management.