### PR TITLE
Encoder debug display support

### DIFF
--- a/common/libs/VkCodecUtils/VulkanFrame.cpp
+++ b/common/libs/VkCodecUtils/VulkanFrame.cpp
@@ -628,15 +628,17 @@ VkResult VulkanFrame<FrameDataType>::DrawFrame( int32_t            renderIndex,
         waitSemaphoreInfos[waitSemaphoreCount].deviceIndex = 0;
         waitSemaphoreCount++;
 
-        signalSemaphoreInfos[signalSemaphoreCount].sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO_KHR;
-        signalSemaphoreInfos[signalSemaphoreCount].pNext = nullptr;
-        signalSemaphoreInfos[signalSemaphoreCount].semaphore = inFrame->consumerCompleteSemaphore;
-        signalSemaphoreInfos[signalSemaphoreCount].value     = inFrame->frameConsumerDoneSemValue;
-        signalSemaphoreInfos[signalSemaphoreCount].stageMask = VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT;
-        signalSemaphoreInfos[signalSemaphoreCount].deviceIndex = 0;
-        signalSemaphoreCount++;
+        if (inFrame->consumerCompleteSemaphore) {
+            signalSemaphoreInfos[signalSemaphoreCount].sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO_KHR;
+            signalSemaphoreInfos[signalSemaphoreCount].pNext = nullptr;
+            signalSemaphoreInfos[signalSemaphoreCount].semaphore = inFrame->consumerCompleteSemaphore;
+            signalSemaphoreInfos[signalSemaphoreCount].value = inFrame->frameConsumerDoneSemValue;
+            signalSemaphoreInfos[signalSemaphoreCount].stageMask = VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT;
+            signalSemaphoreInfos[signalSemaphoreCount].deviceIndex = 0;
+            signalSemaphoreCount++;
 
-        inFrame->hasConsummerSignalSemaphore = true;
+            inFrame->hasConsummerSignalSemaphore = true;
+        }
     }
 
     assert(waitSemaphoreCount <= waitSemaphoreMaxCount);

--- a/vk_video_encoder/demos/vk-video-enc/Main.cpp
+++ b/vk_video_encoder/demos/vk-video-enc/Main.cpp
@@ -156,7 +156,9 @@ int main(int argc, const char* argv[])
         VkSharedBaseObj<Shell> displayShell;
         const Shell::Configuration configuration(encoderConfig->appName.c_str(),
                                                  4, // the display queue size
-                                                 encoderConfig->enableFrameDirectModePresent);
+                                                 encoderConfig->enableFrameDirectModePresent,
+                                                 encoderConfig->encodeWidth,
+                                                 encoderConfig->encodeHeight);
         result = Shell::Create(&vkDevCtxt, configuration, displayShell);
         if (result != VK_SUCCESS) {
             assert(!"Can't allocate display shell! Out of memory!");
@@ -258,6 +260,11 @@ int main(int argc, const char* argv[])
     // Enter the encoding frame loop
     uint32_t curFrameIndex = 0;
     for(; curFrameIndex < encoderConfig->numFrames; curFrameIndex++) {
+
+        if (encoderConfig->enableFramePresent) {
+            // Slow down the display rate to be able to examine the frames
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        }
 
         if (encoderConfig->verboseFrameStruct) {
             std::cout << "####################################################################################" << std::endl

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -69,6 +69,7 @@ static void printHelp(VkVideoCodecOperationFlagBitsKHR codec)
     --deviceID                      <hexadec> : deviceID to be used, \n\
     --deviceUuid                    <string>  : deviceUuid to be used \n\
     --enableHwLoadBalancing                   : enables HW load balancing using multiple encoder devices when available \n\
+    --enableDebugEncoderInputDisplay  none    : Testing only - enable presenting to the display the frames input to the encoder\n\
     --testOutOfOrderRecording                 : Testing only - enable testing for out-of-order-recording\n\
     --intraRefreshCycleDuration     <integer> : Duration of (number of frames in) an intra-refresh cycle\n\
     --intraRefreshMode              <string>  : Intra-refresh mode to be used\n\
@@ -504,6 +505,9 @@ int EncoderConfig::ParseArguments(int argc, const char *argv[])
             // Testing only - don't use this feature for production!
             fprintf(stdout, "Warning: %s should only be used for testing!\n", args[i].c_str());
             enableOutOfOrderRecording = true;
+        } else if (args[i] == "--enableDebugEncoderInputDisplay") {
+            fprintf(stdout, "Warning: %s Enabling the display for testing encoder input frames!\n", args[i].c_str());
+            enableFramePresent = true;
         } else if (args[i] == "--intraRefreshCycleDuration") {
             if (++i >= argc || sscanf(args[i].c_str(), "%u", &intraRefreshCycleDuration) != 1) {
                 fprintf(stderr, "invalid parameter for %s\n", args[i - 1].c_str());


### PR DESCRIPTION
DEBUG ONLY: Encoder input debug display support

    Use the --enableDebugEncoderInputDisplay option
    to present the encoder's input frames to the screen,
    after the staging and compute filter and before the
    encoder.
