### PR TITLE
encoder: flush async pipeline in GetBitstream before shutdown

### DIFF
--- a/common/libs/VkCodecUtils/VkThreadSafeQueue.h
+++ b/common/libs/VkCodecUtils/VkThreadSafeQueue.h
@@ -84,6 +84,14 @@ public:
         return m_queue.size();
     }
 
+    void Drain()
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        std::queue<QueueNodeType> empty;
+        m_queue.swap(empty);
+        m_condProducer.notify_all();
+    }
+
     void SetFlushAndExit()
     {
         std::unique_lock<std::mutex> lock(m_mutex);

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -3181,7 +3181,8 @@ int32_t VkVideoEncoder::DeinitEncoder()
 #endif // VIDEO_DISPLAY_QUEUE_SUPPORT
     m_lastDeferredFrame = nullptr;
 
-    m_vkDevCtx->MultiThreadedQueueWaitIdle(VulkanDeviceContext::ENCODE, 0);
+    if (m_vkDevCtx)
+        m_vkDevCtx->MultiThreadedQueueWaitIdle(VulkanDeviceContext::ENCODE, 0);
 
     if (m_hwLoadBalancingTimelineSemaphore != VK_NULL_HANDLE) {
          m_vkDevCtx->DestroySemaphore(*m_vkDevCtx, m_hwLoadBalancingTimelineSemaphore, NULL);

--- a/vk_video_encoder/src/vulkan_video_encoder.cpp
+++ b/vk_video_encoder/src/vulkan_video_encoder.cpp
@@ -28,7 +28,12 @@ public:
         return m_encoderConfig->numFrames;
     }
     virtual VkResult EncodeNextFrame(int64_t& frameNumEncoded);
-    virtual VkResult GetBitstream() { return VK_SUCCESS; }
+    virtual VkResult GetBitstream() {
+        if (m_encoder) {
+            m_encoder->WaitForThreadsToComplete();
+        }
+        return VK_SUCCESS;
+    }
 
     VulkanVideoEncoderImpl()
     : m_vkDevCtxt()


### PR DESCRIPTION
GetBitstream() was a no-op stub that never flushed the async assembly pipeline. The test app calls GetBitstream() after encoding all frames, expecting it to complete all pending assembly work. Without the flush, deferred frames with unsignaled fences remain in the assembly queue.

Fix: GetBitstream() now calls WaitForThreadsToComplete() which pushes deferred frames, waits for assembly threads to finish, and joins them.

Also adds VkThreadSafeQueue::Drain() utility and m_vkDevCtx null guard in DeinitEncoder() for robustness during partial-init teardown.