### PR TITLE
common: do not modify output filename

### DIFF
--- a/common/libs/VkCodecUtils/VkVideoFrameToFile.cpp
+++ b/common/libs/VkCodecUtils/VkVideoFrameToFile.cpp
@@ -191,21 +191,16 @@ public:
             m_outputFile = nullptr;
         }
 
-        std::string fileNameWithModExt;
         // Check if the file does not have a y4m extension,
         // but y4m format is requested.
         if (y4mFormat && !hasExtension(fileName, ".y4m")) {
             std::cout << std::endl << "y4m output format is requested, ";
             std::cout << "but the output file's (" << fileName << ") extension isn't .y4m!"
                       << std::endl;
-            fileNameWithModExt = fileName + std::string(".y4m");
-            fileName = fileNameWithModExt.c_str();
         } else if ((y4mFormat == false) && !hasExtension(fileName, ".yuv")) {
             std::cout << std::endl << "Raw yuv output format is requested, ";
             std::cout << "but the output file's (" << fileName << ") extension isn't .yuv!"
                       << std::endl;
-            fileNameWithModExt = fileName + std::string(".yuv");
-            fileName = fileNameWithModExt.c_str();
         }
 
         if (fileName != nullptr) {


### PR DESCRIPTION
just inform user that the output filename is not correct but do not modify it.

If the name is changed, fluster can not verify that the ouput file is correct as it is expecting ".out" extension.