### PR TITLE
Rename H.265 aligned picture size parameters for accuracy

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -224,26 +224,26 @@ uint32_t EncoderConfigH265::GetMaxDpbSize(uint32_t pictureSizeInSamplesY, int32_
     return std::min<uint32_t>(maxDpbSize, STD_VIDEO_H265_MAX_DPB_SIZE);
 }
 
-uint32_t EncoderConfigH265::GetCtbAlignedPicSizeInSamples(uint32_t& picWidthInCtbsY, uint32_t& picHeightInCtbsY, bool minCtbsY)
+uint32_t EncoderConfigH265::GetCtbAlignedPicSizeInSamples(uint32_t& alignedPicWidth, uint32_t& alignedPicHeight, bool minCtbsY)
 {
     if (minCtbsY) {
         uint32_t minCbLog2SizeY = cuMinSize + 3;
         uint32_t minCbSizeY = 1 << minCbLog2SizeY;
-        picWidthInCtbsY     = AlignSize(encodeWidth, minCbSizeY);
-        picHeightInCtbsY    = AlignSize(encodeHeight, minCbSizeY);
+        alignedPicWidth     = AlignSize(encodeWidth, minCbSizeY);
+        alignedPicHeight    = AlignSize(encodeHeight, minCbSizeY);
     } else {
         uint32_t ctbLog2SizeY = cuSize + 3;
         uint32_t ctbSizeY     = 1 << ctbLog2SizeY;
-        picWidthInCtbsY       = AlignSize(encodeWidth, ctbSizeY);
-        picHeightInCtbsY      = AlignSize(encodeHeight, ctbSizeY);
+        alignedPicWidth       = AlignSize(encodeWidth, ctbSizeY);
+        alignedPicHeight      = AlignSize(encodeHeight, ctbSizeY);
     }
-    return picWidthInCtbsY * picHeightInCtbsY;
+    return alignedPicWidth * alignedPicHeight;
 }
 
 int8_t EncoderConfigH265::VerifyDpbSize()
 {
-    uint32_t picWidthInCtbsY = 0, picHeightInCtbsY = 0;
-    uint32_t picSize = GetCtbAlignedPicSizeInSamples(picWidthInCtbsY, picHeightInCtbsY);
+    uint32_t widthCtbAligned = 0, heightCtbAligned = 0;
+    uint32_t picSize = GetCtbAlignedPicSizeInSamples(widthCtbAligned, heightCtbAligned);
 
     int32_t levelIdxFound = -1;
     for (size_t i = 0; i < levelLimitsTblSize; i++) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
@@ -133,7 +133,7 @@ struct EncoderConfigH265 : public EncoderConfig {
 
     virtual int DoParseArguments(int argc, const char* argv[]) override;
 
-    uint32_t GetCtbAlignedPicSizeInSamples(uint32_t& picWidthInCtbsY, uint32_t& picHeightInCtbsY, bool minCtbsY = false);
+    uint32_t GetCtbAlignedPicSizeInSamples(uint32_t& alignedPicWidth, uint32_t& alignedPicHeight, bool minCtbsY = false);
 
     uint32_t GetCpbVclFactor();
 


### PR DESCRIPTION
Rename the output parameters of GetCtbAlignedPicSizeInSamples so their names reflect the actual values they carry: aligned picture width and height in samples, not CTB counts.

No functional change.