### PR TITLE
Fix y4m 422 output

### DIFF
--- a/common/libs/VkCodecUtils/VkVideoFrameToFile.cpp
+++ b/common/libs/VkCodecUtils/VkVideoFrameToFile.cpp
@@ -250,6 +250,8 @@ public:
             fprintf(m_outputFile, "A1:1 ");
             if (mpInfo->planesLayout.secondaryPlaneSubsampledX == false) {
                 fprintf(m_outputFile, "C444");
+            } else if (mpInfo->planesLayout.secondaryPlaneSubsampledY == false) {
+                fprintf(m_outputFile, "C422");
             } else {
                 fprintf(m_outputFile, "C420");
             }


### PR DESCRIPTION
The Y4M formatter did not have the necessary output flag for the 4:2:2 format. This would prevent viewer software from opening the Y4M correctly.