### PR TITLE
Encoder fixes+aq

### DIFF
--- a/README-AQ.md
+++ b/README-AQ.md
@@ -433,6 +433,25 @@ The encoder supports the following AQ-related parameters:
 - **Temporal Only**: Set `--temporalAQStrength` to a value in [-1.0, 1.0] and leave `--spatialAQStrength` as default (< -1.0)
 - **Combined Mode**: Set both `--spatialAQStrength` and `--temporalAQStrength` to values in [-1.0, 1.0]
 
+### GPU Selection on Multi-GPU Systems
+
+On systems with more than one GPU, pin the encoder to a specific device:
+
+- `--deviceID <hex>`: Select the Vulkan physical device by PCI device ID
+  (e.g. `--deviceID 0x2C02`). List the installed GPUs with
+  `nvidia-smi --query-gpu=index,name,pci.device_id --format=csv`; the device
+  ID is the upper 16 bits of `pci.device_id` (e.g. `0x2C0210DE` → `0x2C02`).
+- `--deviceUuid <uuid>`: Select the device by UUID instead (useful when two
+  identical GPU models are installed).
+
+The Python helpers `scripts/run_aq_encoder.py` and
+`scripts/aq_quality_benchmark.py` expose the same selection via
+`--device-id` / `--device-uuid`.
+
+**Note:** Not all codecs are supported by every GPU generation. For example,
+AV1 encode requires Ada (RTX 40 series) or newer; on Ampere and older GPUs,
+AV1 encode tests will report that the codec is not supported.
+
 ## Example Commands
 
 > **Note on Bitrate Units**: The `--averageBitrate` parameter is in **bits per second (bps)**.

--- a/common/libs/VkCodecUtils/VulkanFilterYuvCompute.cpp
+++ b/common/libs/VkCodecUtils/VulkanFilterYuvCompute.cpp
@@ -3003,14 +3003,41 @@ size_t VulkanFilterYuvCompute::InitRGBA2YCBCR(std::string& computeShader)
     // 11-12. Write output: packed or planar
     const bool isPackedOutput = (outputMpInfo == nullptr);
     if (isPackedOutput) {
-        // Packed format (e.g. Y410 = A2B10G10R10_UNORM_PACK32).
-        // Single outputImageRGB binding. Channel mapping per Vulkan YCbCr spec:
-        //   R = Cr, G = Y, B = Cb, A = Alpha
-        // Cb/Cr are shifted from [-0.5, 0.5] to [0, 1] for UNORM storage.
-        shaderStr <<
-            "    // Write packed YCbCr (A2B10G10R10: R=Cr, G=Y, B=Cb, A=1)\n"
-            "    imageStore(outputImageRGB, lumaPos, vec4(ycbcr00.z + 0.5, ycbcr00.x, ycbcr00.y + 0.5, 1.0));\n"
-            "    \n";
+        // Single-plane packed YCbCr written through one RGBA-typed storage image.
+        // ycbcr00 = (Y, Cb, Cr); Cb/Cr are shifted from [-0.5,0.5] to [0,1] for
+        // UNORM storage. The channel order depends on the *target* packed
+        // format's in-memory byte order (the storage image is a generic RGBA
+        // format whose channels we repurpose):
+        //
+        //   Y410 (A2B10G10R10_PACK32): mem [U,Y,V,A] in bits → R=Cr,G=Y,B=Cb
+        //   AYUV (R8G8B8A8, mem V,U,Y,A / ffmpeg "vuya")     → R=Cr,G=Cb,B=Y
+        //   Y416 (R16G16B16A16, mem U,Y,V,A / DXGI Y416)     → R=Cb,G=Y,B=Cr
+        //
+        // (4:2:2 packed YUY2/Y210/Y216 are handled separately below, since they
+        //  store two luma per texel at half width.)
+        const char* packedWrite = nullptr;
+        switch (m_outputFormat) {
+            case VK_FORMAT_R8G8B8A8_UNORM: // AYUV: V,U,Y,A
+                packedWrite =
+                    "    // Write packed AYUV (mem V,U,Y,A): R=Cr, G=Cb, B=Y, A=1\n"
+                    "    imageStore(outputImageRGB, lumaPos, vec4(ycbcr00.z + 0.5, ycbcr00.y + 0.5, ycbcr00.x, 1.0));\n"
+                    "    \n";
+                break;
+            case VK_FORMAT_R16G16B16A16_UNORM: // Y416: U,Y,V,A
+                packedWrite =
+                    "    // Write packed Y416 (mem U,Y,V,A): R=Cb, G=Y, B=Cr, A=1\n"
+                    "    imageStore(outputImageRGB, lumaPos, vec4(ycbcr00.y + 0.5, ycbcr00.x, ycbcr00.z + 0.5, 1.0));\n"
+                    "    \n";
+                break;
+            case VK_FORMAT_A2B10G10R10_UNORM_PACK32: // Y410
+            default:
+                packedWrite =
+                    "    // Write packed YCbCr (A2B10G10R10/Y410: R=Cr, G=Y, B=Cb, A=1)\n"
+                    "    imageStore(outputImageRGB, lumaPos, vec4(ycbcr00.z + 0.5, ycbcr00.x, ycbcr00.y + 0.5, 1.0));\n"
+                    "    \n";
+                break;
+        }
+        shaderStr << packedWrite;
     } else {
         // Multi-planar output: separate Y and chroma plane writes
         GenWriteYBlock(shaderStr, chromaHorzRatio, chromaVertRatio);

--- a/common/libs/VkCodecUtils/VulkanSamplerYcbcrConversion.cpp
+++ b/common/libs/VkCodecUtils/VulkanSamplerYcbcrConversion.cpp
@@ -50,9 +50,28 @@ VkResult VulkanSamplerYcbcrConversion::CreateVulkanSampler(const VulkanDeviceCon
     VkSamplerYcbcrConversionInfo* pSamplerColorConversion = NULL;
     VkSamplerYcbcrConversionInfo samplerColorConversion = VkSamplerYcbcrConversionInfo();
     const VkMpFormatInfo* mpInfo = pSamplerYcbcrConversionCreateInfo ? YcbcrVkFormatInfo(pSamplerYcbcrConversionCreateInfo->format) : nullptr;
-    if (mpInfo) {
 
+    // Always retain the requested conversion create-info so callers that only
+    // need the color-model/range (e.g. the RGBA2YCBCR compute filter, which
+    // writes YCbCr via a storage image and never samples through a conversion)
+    // can read it back via GetSamplerYcbcrConversionCreateInfo(). Previously
+    // this was only stored inside the mpInfo branch, so packed/color output
+    // formats silently fell back to a default (RGB-identity) matrix.
+    if (pSamplerYcbcrConversionCreateInfo) {
         memcpy(&m_samplerYcbcrConversionCreateInfo, pSamplerYcbcrConversionCreateInfo, sizeof(m_samplerYcbcrConversionCreateInfo));
+    }
+
+    // Only create an actual VkSamplerYcbcrConversion object for multi-planar
+    // YCbCr formats that are meant to be *sampled* through the conversion.
+    // Single-plane interleaved 4:2:2 formats (G8B8G8R8_422 / G10X6...422 /
+    // G16B16G16R16_422) are consumed as packed byte blobs (NVCUVID/NVENC input)
+    // and, on NVIDIA, don't advertise COSITED/MIDPOINT chroma sampling features,
+    // so creating a conversion for them fails validation. Skip the object for
+    // those; the stored create-info above still carries the color matrix.
+    const bool isSinglePlaneInterleaved =
+        mpInfo && (mpInfo->planesLayout.layout == YCBCR_SINGLE_PLANE_INTERLEAVED);
+    if (mpInfo && !isSinglePlaneInterleaved) {
+
         result = m_vkDevCtx->CreateSamplerYcbcrConversion(*m_vkDevCtx, &m_samplerYcbcrConversionCreateInfo, NULL, &m_samplerYcbcrConversion);
         if (result != VK_SUCCESS) {
             return result;

--- a/scripts/aq_quality_benchmark.py
+++ b/scripts/aq_quality_benchmark.py
@@ -256,7 +256,13 @@ def run_encoder(
         cmd.extend(["--contentHints", args.content_hints])
     if args.tuning_mode:
         cmd.extend(["--tuningMode", args.tuning_mode])
-    
+
+    # Device selection (multi-GPU systems)
+    if getattr(args, 'device_id', None):
+        cmd.extend(["--deviceID", args.device_id])
+    if getattr(args, 'device_uuid', None):
+        cmd.extend(["--deviceUuid", args.device_uuid])
+
     # Set AQ dump directory - use explicit aq_dump_dir base if provided, else output_dir
     if hasattr(args, 'aq_dump_dir') and args.aq_dump_dir:
         aq_dump_dir = args.aq_dump_dir / f"aq_dump_{config.name}"
@@ -955,6 +961,14 @@ For more information, see README-AQ.md in the vulkan-video-samples repository.
     bench.add_argument("--temporal-aq-strength", type=float, default=0.0,
                        help="Temporal AQ strength [-1.0 to 1.0] for temporal/combined modes. "
                             "0.0=default strength, positive=stronger, negative=weaker (default: 0.0)")
+    bench.add_argument("--device-id",
+                      help="Vulkan physical device to use, as a hex PCI device ID "
+                           "(e.g. 0x2C02). List devices with 'nvidia-smi --query-gpu="
+                           "index,name,pci.device_id --format=csv'; the device ID is "
+                           "the upper 16 bits of pci.device_id")
+    bench.add_argument("--device-uuid",
+                      help="Vulkan physical device to use, by device UUID string "
+                           "(alternative to --device-id)")
     bench.add_argument("--aq-dump-dir", type=Path,
                        help="Base directory for AQ library dumps. If not specified, uses "
                             "<output-dir>/aq_dump_<config>/ for each configuration")

--- a/scripts/run_aq_encoder.py
+++ b/scripts/run_aq_encoder.py
@@ -179,7 +179,13 @@ def build_command(args):
     # AQ dump directory
     if args.aq_dump_dir:
         cmd.extend(["--aqDumpDir", str(args.aq_dump_dir)])
-    
+
+    # Device selection (multi-GPU systems)
+    if args.device_id:
+        cmd.extend(["--deviceID", args.device_id])
+    if args.device_uuid:
+        cmd.extend(["--deviceUuid", args.device_uuid])
+
     return cmd
 
 
@@ -281,7 +287,21 @@ Examples:
         type=Path,
         help="Directory for AQ dump files (default: ./aqDump)"
     )
-    
+
+    # Device selection (multi-GPU systems)
+    parser.add_argument(
+        "--device-id",
+        help="Vulkan physical device to use, as a hex PCI device ID "
+             "(e.g. 0x2C02). List devices with 'nvidia-smi --query-gpu="
+             "index,name,pci.device_id --format=csv'; the device ID is the "
+             "upper 16 bits of pci.device_id. Default: encoder's default pick"
+    )
+    parser.add_argument(
+        "--device-uuid",
+        help="Vulkan physical device to use, by device UUID string "
+             "(alternative to --device-id)"
+    )
+
     # Frame parameters
     parser.add_argument(
         "--num-frames",

--- a/vk_video_encoder/include/vulkan_video_encoder_ext.h
+++ b/vk_video_encoder/include/vulkan_video_encoder_ext.h
@@ -82,6 +82,13 @@ struct VkVideoEncoderConfig {
     // Quality
     uint32_t qualityLevel;      // 0 = default
 
+    // Tuning mode (VkVideoEncodeTuningModeKHR):
+    //   0 = DEFAULT, 1 = HIGH_QUALITY, 2 = LOW_LATENCY,
+    //   3 = ULTRA_LOW_LATENCY, 4 = LOSSLESS
+    // LOSSLESS engages transquant-bypass + QP0 in the codec config, producing
+    // bit-exact output (per the Vulkan spec). Requires rateControlMode DISABLED.
+    uint32_t tuningMode;
+
     // Color info (VUI)
     uint8_t colourPrimaries;
     uint8_t transferCharacteristics;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -1043,6 +1043,9 @@ VkResult EncoderConfig::CreateCodecConfig(int argc, const char *argv[],
             return result;
         }
 
+        if (getenv("VKENC_DEBUG_PSNR")) {
+            vkEncoderConfigh265->enablePsnrMetrics = 1;
+        }
         encoderConfig = vkEncoderConfigh265;
         return VK_SUCCESS;
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -2759,8 +2759,24 @@ VkResult VkVideoEncoder::RecordVideoCodingCmd(VkSharedBaseObj<VkVideoEncodeFrame
                                                           encodeFrameInfo->controlCmd};
         vkDevCtx->CmdControlVideoCodingKHR(cmdBuf, &renderControlInfo);
 
-        m_beginRateControlInfo = *(VkVideoEncodeRateControlInfoKHR*)encodeFrameInfo->pControlCmdChain;
-        const_cast<VkBaseInStructure*>(static_cast<const VkBaseInStructure*>(m_beginRateControlInfo.pNext))->pNext = NULL;
+        // Cache the new session rate-control state for subsequent frames' BeginCoding.
+        // The chain head is the codec-specific RC struct (e.g.
+        // VkVideoEncodeH265RateControlInfoKHR), so walk the chain for the base RC
+        // struct — casting the head read gopFrameCount as rateControlMode.
+        for (const VkBaseInStructure* p =
+                 reinterpret_cast<const VkBaseInStructure*>(encodeFrameInfo->pControlCmdChain);
+             p != nullptr; p = p->pNext) {
+            if (p->sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR) {
+                m_beginRateControlInfo = *reinterpret_cast<const VkVideoEncodeRateControlInfoKHR*>(p);
+                m_beginRateControlInfo.pNext = nullptr;
+                // The frame's rateControlLayersInfo array is pool-recycled; point the
+                // cached copy at the encoder's persistent layer storage instead.
+                if (m_beginRateControlInfo.layerCount > 0) {
+                    m_beginRateControlInfo.pLayers = m_rateControlLayersInfo;
+                }
+                break;
+            }
+        }
     }
 
     if (m_videoMaintenance1FeaturesSupported)

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -1281,6 +1281,12 @@ void VkVideoEncoder::AssemblyWorkerThread(int threadId)
             continue;
         }
 
+        // The threaded (ext streaming) assembly path does not go through
+        // AssembleBitstreamData, so PSNR / recon capture is done here.
+        if (m_psnr && m_psnr->Enabled()) {
+            m_psnr->ComputeFramePsnr(frame.get());
+        }
+
         {
             std::unique_lock<std::mutex> lock(m_assemblyFileMutex);
             m_assemblyOrderCV.wait(lock, [&] {
@@ -2749,6 +2755,13 @@ VkResult VkVideoEncoder::RecordVideoCodingCmd(VkSharedBaseObj<VkVideoEncodeFrame
     }
 
     encodeBeginInfo.pNext = &m_beginRateControlInfo;
+
+    if (getenv("VKENC_DEBUG_PSNR")) {
+        fprintf(stderr, "[BEGINRC] picType=%d controlCmd=0x%x beginRCmode=%d\n",
+                (int)encodeFrameInfo->gopPosition.pictureType,
+                (unsigned)encodeFrameInfo->controlCmd,
+                (int)m_beginRateControlInfo.rateControlMode);
+    }
 
     vkDevCtx->CmdBeginVideoCodingKHR(cmdBuf, &encodeBeginInfo);
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -2944,12 +2944,69 @@ VkResult VkVideoEncoder::SubmitVideoCodingCmds(VkSharedBaseObj<VkVideoEncodeFram
         signalSemaphoreCount++;
     }
 
-    // Path A (direct encode, no staging): inject external signal semaphores
-    // into the encode submit. For Paths B/C the staging submit handles these.
+    // Path A (direct encode, no staging): signal the producer's input-release
+    // timeline (signal semaphore index 0) at queue flush points. Submits
+    // arrive here in ENCODE order — under B-frame GOPs each ordered batch is
+    // a reference frame followed by the deferred B-frames that precede it in
+    // input order — so signaling each frame's own release value would free
+    // the B inputs while the encode engine still has to read them, with
+    // non-monotonic timeline values. The batch chain tail
+    // (dependantFrames == nullptr) is the flush point: every input received
+    // so far has been encode-submitted, and queue completion is FIFO, so
+    // when this submit retires all of them are consumed. Signal the max
+    // release value submitted so far — one monotonic signal per batch,
+    // correct for any intra-batch order. Single-frame batches degenerate to
+    // per-frame signaling. Values of 0 (binary semantics) and extra signal
+    // semaphores (index 1+) pass through per-frame as before. For Paths B/C
+    // the staging submit consumes the input in input order instead.
     if (encodeFrameInfo->isExternalInput && !encodeFrameInfo->inputCmdBuffer &&
         !encodeFrameInfo->inputSignalSemaphores.empty()) {
-        for (size_t i = 0; i < encodeFrameInfo->inputSignalSemaphores.size() &&
-                           signalSemaphoreCount < signalSemaphoreMaxCount; i++) {
+        size_t firstPassThroughIdx = 0;
+        const uint64_t releaseValue = !encodeFrameInfo->inputSignalSemaphoreValues.empty()
+                                          ? encodeFrameInfo->inputSignalSemaphoreValues[0] : 0;
+        if (releaseValue != 0) {
+            firstPassThroughIdx = 1;
+            if (releaseValue > m_maxSubmittedInputReleaseId) {
+                m_maxSubmittedInputReleaseId = releaseValue;
+            }
+            // Flush point = last EXTERNAL frame of the ordered batch. The
+            // chain may end with codec pseudo-frames that are not external
+            // inputs and read no input image (e.g. the AV1 show-existing
+            // overlay node InsertOrdered appends after the B-frames), so
+            // "dependantFrames == nullptr" alone would miss the tail.
+            bool queueFlushPoint = true;
+            for (const VkVideoEncodeFrameInfo* next = encodeFrameInfo->dependantFrames.get();
+                 next != nullptr; next = next->dependantFrames.get()) {
+                if (next->isExternalInput) {
+                    queueFlushPoint = false;
+                    break;
+                }
+            }
+            static const bool releaseDebug = (getenv("VKENC_RELEASE_DEBUG") != nullptr);
+            if (releaseDebug) {
+                fprintf(stderr, "[RELDBG] submit relVal=%llu max=%llu last=%llu tail=%d inOrd=%llu encOrd=%llu\n",
+                        (unsigned long long)releaseValue,
+                        (unsigned long long)m_maxSubmittedInputReleaseId,
+                        (unsigned long long)m_lastSignaledInputReleaseId,
+                        (int)queueFlushPoint,
+                        (unsigned long long)encodeFrameInfo->gopPosition.inputOrder,
+                        (unsigned long long)encodeFrameInfo->gopPosition.encodeOrder);
+            }
+            if (queueFlushPoint &&
+                (m_maxSubmittedInputReleaseId > m_lastSignaledInputReleaseId) &&
+                (signalSemaphoreCount < signalSemaphoreMaxCount)) {
+                signalSemaphoreInfos[signalSemaphoreCount].sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO_KHR;
+                signalSemaphoreInfos[signalSemaphoreCount].semaphore = encodeFrameInfo->inputSignalSemaphores[0];
+                signalSemaphoreInfos[signalSemaphoreCount].value = m_maxSubmittedInputReleaseId;
+                signalSemaphoreInfos[signalSemaphoreCount].stageMask = VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR;
+                signalSemaphoreInfos[signalSemaphoreCount].deviceIndex = 0;
+                signalSemaphoreCount++;
+                m_lastSignaledInputReleaseId = m_maxSubmittedInputReleaseId;
+            }
+        }
+        for (size_t i = firstPassThroughIdx;
+             i < encodeFrameInfo->inputSignalSemaphores.size() &&
+             signalSemaphoreCount < signalSemaphoreMaxCount; i++) {
             signalSemaphoreInfos[signalSemaphoreCount].sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO_KHR;
             signalSemaphoreInfos[signalSemaphoreCount].semaphore = encodeFrameInfo->inputSignalSemaphores[i];
             signalSemaphoreInfos[signalSemaphoreCount].value =

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
@@ -401,6 +401,11 @@ public:
             lastFrame = false;
             controlCmd = VkVideoCodingControlFlagsKHR();
             pControlCmdChain = nullptr;
+            // Pool nodes are recycled into non-external roles (e.g. AV1
+            // show-existing pseudo-frames); stale external-input state would
+            // make them inject stale release-semaphore signals and defeat
+            // the flush-point (last-external-frame) detection.
+            ClearExternalInputSync();
             assert(qualityLevelInfo.sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR);
             assert(rateControlInfo.sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR);
             assert(rateControlLayersInfo[0].sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR);
@@ -572,6 +577,8 @@ public:
         , m_numDeferredFrames()
         , m_numDeferredRefFrames()
         , m_holdRefFramesInQueue(1)
+        , m_maxSubmittedInputReleaseId(0)
+        , m_lastSignaledInputReleaseId(0)
         , m_controlCmd(VK_VIDEO_CODING_CONTROL_RESET_BIT_KHR |
                        VK_VIDEO_CODING_CONTROL_ENCODE_QUALITY_LEVEL_BIT_KHR |
                        VK_VIDEO_CODING_CONTROL_ENCODE_RATE_CONTROL_BIT_KHR)
@@ -934,6 +941,19 @@ protected:
     uint32_t                                 m_numDeferredFrames;
     uint32_t                                 m_numDeferredRefFrames;
     uint32_t                                 m_holdRefFramesInQueue;
+    // External-input release signaling at queue flush points (Path A).
+    // Encode submits arrive in encode order, which under B-frame GOPs
+    // differs from input order, so a frame's own release value must not be
+    // signaled on its submit (a reordered reference would release the B
+    // inputs it precedes while their encodes still have to read them).
+    // The end of each ordered batch (reference frame + its deferred
+    // B-frames) is a natural flush point: every input received so far has
+    // been encode-submitted, so the batch's last submit signals the max
+    // release value seen — one monotonic signal releasing the whole
+    // sequence, valid for any intra-batch order. Single-frame batches
+    // (no B-frames) degenerate to per-frame signaling.
+    uint64_t                                 m_maxSubmittedInputReleaseId;
+    uint64_t                                 m_lastSignaledInputReleaseId;
     VkVideoCodingControlFlagsKHR             m_controlCmd;
     VkSharedBaseObj<VulkanVideoImagePool>    m_linearInputImagePool;
     VkSharedBaseObj<VulkanVideoImagePool>    m_inputImagePool;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.cpp
@@ -524,6 +524,15 @@ VkResult VkVideoEncoderH265::EncodeFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>
         for (uint32_t i = 0; i < pFrameInfo->pictureInfo.naluSliceSegmentEntryCount; i++) {
             pFrameInfo->naluSliceSegmentInfo[i].constantQp = constantQp;
         }
+        if (getenv("VKENC_DEBUG_PSNR")) {
+            fprintf(stderr, "[QPDBG] picType=%d constantQp=%d (qpI=%d qpP=%d qpB=%d) rcMode=%d\n",
+                    (int)encodeFrameInfo->gopPosition.pictureType, constantQp,
+                    encodeFrameInfo->constQp.qpIntra, encodeFrameInfo->constQp.qpInterP,
+                    encodeFrameInfo->constQp.qpInterB, (int)m_rateControlInfo.rateControlMode);
+        }
+    } else if (getenv("VKENC_DEBUG_PSNR")) {
+        fprintf(stderr, "[QPDBG] rcMode=%d NOT DISABLED (picType=%d) -> QP not forced\n",
+                (int)m_rateControlInfo.rateControlMode, (int)encodeFrameInfo->gopPosition.pictureType);
     }
 
     pFrameInfo->stdPictureInfo.flags.is_reference = m_encoderConfig->gopStructure.IsFrameReference(encodeFrameInfo->gopPosition);

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderPsnr.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderPsnr.cpp
@@ -227,18 +227,17 @@ void VkVideoEncoderPsnr::ComputeFramePsnr(void* encodeFrameInfoVoid)
     const size_t uPlaneSizeRecon = (size_t)(encodeChromaW * encodeChromaH);
     const uint32_t numPlanes = std::min(3u, m_encoderConfig->input.numPlanes);
 
-    if (encodeFrameInfo.psnrFrameData.psnrInputY.empty()) {
-        return;
-    }
     const uint8_t* inputY = encodeFrameInfo.psnrFrameData.psnrInputY.data();
     const uint8_t* inputU = encodeFrameInfo.psnrFrameData.psnrInputU.data();
     const uint8_t* inputV = encodeFrameInfo.psnrFrameData.psnrInputV.data();
     const size_t inputYSize = encodeFrameInfo.psnrFrameData.psnrInputY.size();
     const size_t inputUSize = encodeFrameInfo.psnrFrameData.psnrInputU.size();
     const size_t inputVSize = encodeFrameInfo.psnrFrameData.psnrInputV.size();
-    if (inputYSize != yPlaneSizeInput) {
-        return;
-    }
+    // Ext (SubmitExternalFrame) path never runs CaptureInput (no CPU input buffer),
+    // so psnrInput* is empty. Still read back + dump the reconstructed frame so we can
+    // compare the recon against the reference offline; only skip the input-vs-recon math.
+    const bool haveInput = (!encodeFrameInfo.psnrFrameData.psnrInputY.empty()) &&
+                           (inputYSize == yPlaneSizeInput);
 
     if (encodeFrameInfo.encodeCmdBuffer == nullptr) {
         return;
@@ -313,14 +312,14 @@ void VkVideoEncoderPsnr::ComputeFramePsnr(void* encodeFrameInfoVoid)
 
     m_vkDevCtx->UnmapMemory(device, mem);
 
-#define VKVENC_DEBUG_DUMP_PSNR_FRAMES 0
+#define VKVENC_DEBUG_DUMP_PSNR_FRAMES 1
 #if VKVENC_DEBUG_DUMP_PSNR_FRAMES
-    {
+    if (getenv("VKENC_DEBUG_DUMP_FRAMES")) {
         const uint32_t inputOrder = (uint32_t)encodeFrameInfo.gopPosition.inputOrder;
         char filename[256];
         snprintf(filename, sizeof(filename), "input_frame_%05u_%ux%u.yuv", inputOrder, width, height);
-        std::ofstream outInput(filename, std::ios::binary);
-        if (outInput) {
+        std::ofstream outInput(haveInput ? filename : "/dev/null", std::ios::binary);
+        if (haveInput && outInput) {
             outInput.write(reinterpret_cast<const char*>(inputY), yPlaneSizeInput);
             if ((numPlanes >= 2) && (inputUSize >= uPlaneSizeInput)) {
                 outInput.write(reinterpret_cast<const char*>(inputU), uPlaneSizeInput);
@@ -361,23 +360,25 @@ void VkVideoEncoderPsnr::ComputeFramePsnr(void* encodeFrameInfoVoid)
         return (mse <= 1e-10) ? 100.0 : (10.0 * log10((255.0 * 255.0) / mse));
     };
 
-    double framePsnrY = computePlanePsnr(inputY, width, m_psnrReconY.data(), encodeW, width, height);
-    if (framePsnrY >= 0.0) {
-        m_psnrSum += framePsnrY;
-    }
-    if ((numPlanes >= 2) && (inputUSize == uPlaneSizeInput) && (m_psnrReconU.size() >= uPlaneSizeInput)) {
-        double framePsnrU = computePlanePsnr(inputU, chromaW, m_psnrReconU.data(), encodeChromaW, chromaW, chromaH);
-        if (framePsnrU >= 0.0) {
-            m_psnrSumU += framePsnrU;
+    if (haveInput) {
+        double framePsnrY = computePlanePsnr(inputY, width, m_psnrReconY.data(), encodeW, width, height);
+        if (framePsnrY >= 0.0) {
+            m_psnrSum += framePsnrY;
         }
-    }
-    if ((numPlanes >= 3) && (inputVSize == uPlaneSizeInput) && (m_psnrReconV.size() >= uPlaneSizeInput)) {
-        double framePsnrV = computePlanePsnr(inputV, chromaW, m_psnrReconV.data(), encodeChromaW, chromaW, chromaH);
-        if (framePsnrV >= 0.0) {
-            m_psnrSumV += framePsnrV;
+        if ((numPlanes >= 2) && (inputUSize == uPlaneSizeInput) && (m_psnrReconU.size() >= uPlaneSizeInput)) {
+            double framePsnrU = computePlanePsnr(inputU, chromaW, m_psnrReconU.data(), encodeChromaW, chromaW, chromaH);
+            if (framePsnrU >= 0.0) {
+                m_psnrSumU += framePsnrU;
+            }
         }
+        if ((numPlanes >= 3) && (inputVSize == uPlaneSizeInput) && (m_psnrReconV.size() >= uPlaneSizeInput)) {
+            double framePsnrV = computePlanePsnr(inputV, chromaW, m_psnrReconV.data(), encodeChromaW, chromaW, chromaH);
+            if (framePsnrV >= 0.0) {
+                m_psnrSumV += framePsnrV;
+            }
+        }
+        m_psnrFrameCount++;
     }
-    m_psnrFrameCount++;
     if (encodeFrameInfo.psnrFrameData.psnrStagingImage) {
         encodeFrameInfo.psnrFrameData.psnrStagingImage = nullptr;
     }

--- a/vk_video_encoder/src/vulkan_video_encoder_ext.cpp
+++ b/vk_video_encoder/src/vulkan_video_encoder_ext.cpp
@@ -279,8 +279,15 @@ VkResult VulkanVideoEncoderExtImpl::BuildEncoderConfig(
         std::cout << "  [" << i << "] " << argv[i] << "\n";
     }
 
-    return EncoderConfig::CreateCodecConfig(
+    VkResult ccResult = EncoderConfig::CreateCodecConfig(
         static_cast<int>(argv.size()), argv.data(), outConfig);
+    // DEBUG: enable the encoder's built-in input-vs-reconstructed PSNR so we can
+    // tell whether the ext encode itself is lossy (input vs recon) independent of
+    // the decode/reference roundtrip.
+    if (ccResult == VK_SUCCESS && outConfig && getenv("VKENC_DEBUG_PSNR")) {
+        outConfig->enablePsnrMetrics = 1;
+    }
+    return ccResult;
 }
 
 //=============================================================================

--- a/vk_video_encoder/src/vulkan_video_encoder_ext.cpp
+++ b/vk_video_encoder/src/vulkan_video_encoder_ext.cpp
@@ -228,6 +228,15 @@ VkResult VulkanVideoEncoderExtImpl::BuildEncoderConfig(
         argStrings.push_back("--gopFrameCount");
         argStrings.push_back(std::to_string(extConfig.gopLength));
     }
+    // Consecutive-B count: pass through when the caller sets it; otherwise
+    // EncoderConfig adopts the codec's driver-preferred value from the
+    // quality-level caps (5 for AV1 when supported). B-frame GOPs reorder the
+    // encode submissions relative to the input order; the producer's
+    // input-release timeline stays correct because VkVideoEncoder signals
+    // the release at queue flush points (end of each ordered batch) with
+    // the max submitted release value — see SubmitVideoCodingCmds. Note the
+    // producer's frame pool must be deeper than one mini-GOP (B count + 1),
+    // since a mini-GOP's inputs are held until its batch flushes.
     if (extConfig.consecutiveBFrames > 0) {
         argStrings.push_back("--consecutiveBFrameCount");
         argStrings.push_back(std::to_string(extConfig.consecutiveBFrames));

--- a/vk_video_encoder/src/vulkan_video_encoder_ext.cpp
+++ b/vk_video_encoder/src/vulkan_video_encoder_ext.cpp
@@ -181,15 +181,47 @@ VkResult VulkanVideoEncoderExtImpl::BuildEncoderConfig(
 
     // Frame rate: no CLI arg for this in ParseArguments — set via member directly after config
 
-    // Bitrate (note: lowercase 'r' — --averageBitrate, not --averageBitRate)
-    if (extConfig.averageBitrate > 0) {
-        argStrings.push_back("--averageBitrate");
-        argStrings.push_back(std::to_string(extConfig.averageBitrate));
+    // Tuning mode (VkVideoEncodeTuningModeKHR). LOSSLESS engages transquant
+    // bypass + QP0 in the codec config.
+    const bool lossless = (extConfig.tuningMode == 4 /* LOSSLESS */);
+    switch (extConfig.tuningMode) {
+        case 1: argStrings.push_back("--tuningMode"); argStrings.push_back("highquality"); break;
+        case 2: argStrings.push_back("--tuningMode"); argStrings.push_back("lowlatency"); break;
+        case 3: argStrings.push_back("--tuningMode"); argStrings.push_back("ultralowlatency"); break;
+        case 4: argStrings.push_back("--tuningMode"); argStrings.push_back("lossless"); break;
+        default: break;
     }
-    if (extConfig.maxBitrate > 0) {
-        argStrings.push_back("--maxBitrate");
-        argStrings.push_back(std::to_string(extConfig.maxBitrate));
+
+    // Rate control. Constant-QP (a.k.a. DISABLED) when explicitly requested or
+    // when lossless. Otherwise forward the selected bitrate mode. Previously the
+    // ext path forwarded ONLY --averageBitrate with no mode, so constant-QP and
+    // lossless could never be requested and QP0 was dropped.
+    const bool constantQp = (extConfig.rateControlMode == 1 /* DISABLED */) || lossless;
+    if (constantQp) {
+        argStrings.push_back("--rateControlMode");
+        argStrings.push_back("disabled");
+        // Forward QP including 0 (lossless). For lossless, default unset QP to 0.
+        int32_t qpI = (extConfig.constQpI >= 0) ? extConfig.constQpI : (lossless ? 0 : 26);
+        int32_t qpP = (extConfig.constQpP >= 0) ? extConfig.constQpP : qpI;
+        int32_t qpB = (extConfig.constQpB >= 0) ? extConfig.constQpB : qpP;
+        argStrings.push_back("--qpI"); argStrings.push_back(std::to_string(qpI));
+        argStrings.push_back("--qpP"); argStrings.push_back(std::to_string(qpP));
+        argStrings.push_back("--qpB"); argStrings.push_back(std::to_string(qpB));
+    } else {
+        // Explicit RC mode selector so behavior is deterministic (2=CBR, 3=VBR).
+        if (extConfig.rateControlMode == 2)      { argStrings.push_back("--rateControlMode"); argStrings.push_back("cbr"); }
+        else if (extConfig.rateControlMode == 3) { argStrings.push_back("--rateControlMode"); argStrings.push_back("vbr"); }
+        if (extConfig.averageBitrate > 0) {
+            argStrings.push_back("--averageBitrate");
+            argStrings.push_back(std::to_string(extConfig.averageBitrate));
+        }
+        if (extConfig.maxBitrate > 0) {
+            argStrings.push_back("--maxBitrate");
+            argStrings.push_back(std::to_string(extConfig.maxBitrate));
+        }
     }
+    if (extConfig.minQp > 0) { argStrings.push_back("--minQp"); argStrings.push_back(std::to_string(extConfig.minQp)); }
+    if (extConfig.maxQp > 0) { argStrings.push_back("--maxQp"); argStrings.push_back(std::to_string(extConfig.maxQp)); }
 
     // GOP
     if (extConfig.gopLength > 0) {
@@ -199,16 +231,6 @@ VkResult VulkanVideoEncoderExtImpl::BuildEncoderConfig(
     if (extConfig.consecutiveBFrames > 0) {
         argStrings.push_back("--consecutiveBFrameCount");
         argStrings.push_back(std::to_string(extConfig.consecutiveBFrames));
-    }
-
-    // QP — only pass when explicitly set (> 0); 0 is default/unused
-    if (extConfig.constQpI > 0) {
-        argStrings.push_back("--qpI");
-        argStrings.push_back(std::to_string(extConfig.constQpI));
-    }
-    if (extConfig.constQpP > 0) {
-        argStrings.push_back("--qpP");
-        argStrings.push_back(std::to_string(extConfig.constQpP));
     }
 
     // Quality


### PR DESCRIPTION
3fd21f01 vk-encoder debug: env-gated PSNR/recon capture for the ext streaming path
02c9b2bd VkVideoEncoder: reordering-safe input-release signaling at queue flush points for ext streaming
84ccffa1 VkVideoEncoder: fix wrong-struct copy when caching BeginCoding rate-control state
43feac21 VkVideoEncoderExt: forward rate-control mode, tuning, and QP0 (lossless)
46dedd68 VkCodecUtils: correct packed YCbCr output-write + sampler conversion
9d32d2ae scripts: add GPU selection for multi-GPU systems to AQ helper scripts