### PR TITLE
fix: allocate a fresh AV1 bitstream buffer per frame

### DIFF
--- a/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
@@ -2455,14 +2455,27 @@ bool VulkanAV1Decoder::ParseByteStream(const VkParserBitstreamPacket* pck, size_
         uint32_t frame_size = 0;
         frame_size = datasize;
 
-        if (frame_size > (uint32_t)m_bitstreamDataLen) {
-            if (!resizeBitstreamBuffer(frame_size - (m_bitstreamDataLen))) {
-                // Error: Failed to resize bitstream buffer
+        if (datasize > 0) {
+            // Per-frame bitstream buffer (same pattern as VP9 ParseByteStream /
+            // H.264 swapBitstreamBuffer). end_of_picture keeps a shared_ptr to
+            // the previous buffer for in-flight vkCmdDecodeVideoKHR
+            // VIDEO_DECODE_READ; memcpy onto that live buffer is a host WAR and
+            // emptied AV1 OPTIMAL under async multi-frame dump.
+            VkDeviceSize needSize = std::max(m_bitstreamDataLen, (VkDeviceSize)frame_size);
+            VkSharedBaseObj<VulkanBitstreamBuffer> bitstreamBuffer;
+            assert(m_pClient);
+            m_pClient->GetBitstreamBuffer(needSize,
+                                          m_bufferOffsetAlignment, m_bufferSizeAlignment,
+                                          nullptr, 0, bitstreamBuffer);
+            if (!bitstreamBuffer) {
                 return false;
             }
-        }
+            m_bitstreamDataLen = m_bitstreamData.SetBitstreamBuffer(bitstreamBuffer);
+            if (m_bitstreamData.GetBitstreamPtr() == nullptr ||
+                m_bitstreamDataLen < (VkDeviceSize)frame_size) {
+                return false;
+            }
 
-        if (datasize > 0) {
             m_nalu.start_offset = 0;
             m_nalu.end_offset = frame_size;
             memcpy(m_bitstreamData.GetBitstreamPtr(), pdataStart, frame_size);


### PR DESCRIPTION
## Summary
- AV1 `ParseByteStream` reused one mapped bitstream buffer across frames and `memcpy`'d the next frame over it while a prior picture still held that buffer for an in-flight `vkCmdDecodeVideoKHR`.
- That is a host write-after-read on the decode source bitstream range: Vulkan Video decode reads that range with `VK_ACCESS_2_VIDEO_DECODE_READ_BIT_KHR` in `VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR` (Vulkan Spec, [Video Decode Operations](https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#video-decode-operations); decode steps read encoded data from `srcBuffer` / `srcBufferRange`).
- For AV1, that range’s contents are the frame/tile OBUs interpreted per [AV1 Decode Bitstream Data Access](https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#decode-av1-bitstream-data-access), which points at AV1 Spec §§5.9–5.11 / 6.8–6.10 ([AOMedia AV1 Spec](https://aomediacodec.github.io/av1-spec/av1-spec.pdf); syntax/semantics for `frame_obu` / `tile_group_obu`).
- Fix: before each frame `memcpy`, allocate a fresh pool buffer via `GetBitstreamBuffer` (same pattern as VP9 `ParseByteStream` / H.264 `swapBitstreamBuffer`) so each in-flight decode keeps stable bitstream bytes until completion.